### PR TITLE
Add Lv6 SR Latch puzzle and fix FLIPFLOP module registration

### DIFF
--- a/packages/language/src/internal-model/program.ts
+++ b/packages/language/src/internal-model/program.ts
@@ -1,5 +1,5 @@
 import { Program as ProgramAst } from "../parser/ast";
-import { BitinModule, BitoutModule, createModule, NandModule } from "./module";
+import { BitinModule, BitoutModule, createModule, FlipflopModule, NandModule } from "./module";
 import { Variable } from "./variable";
 
 export class Program {
@@ -12,7 +12,7 @@ export class Program {
         name: "Program",
         definitionStatements: this.programAst.statements,
       },
-      [new NandModule(), new BitinModule(), new BitoutModule()],
+      [new NandModule(), new BitinModule(), new BitoutModule(), new FlipflopModule()],
     );
     this.variable = new ProgramModule().createVariable("PROGRAM");
   }

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -117,4 +117,31 @@ VAR out BITOUT`,
     editableCode: `# NANDゲートを使って回路を組み立ててください
 `,
   },
+  {
+    id: 6,
+    title: "Lv6: SR Latch",
+    description:
+      "FLIPFLOPを使ってSRラッチを作ってください。\nsが1のときqを1にセット、rが1のときqを0にリセットします。\nどちらも0のときは前の状態を保持します。\n(テストは順番に実行され、状態が引き継がれます)",
+    inputNames: ["s", "r"],
+    outputNames: ["q"],
+    testCases: [
+      // Initial state: q=0
+      tc({ s: false, r: false }, { q: false }),
+      // Set: q becomes 1
+      tc({ s: true, r: false }, { q: true }),
+      // Hold: q stays 1
+      tc({ s: false, r: false }, { q: true }),
+      // Reset: q becomes 0
+      tc({ s: false, r: true }, { q: false }),
+      // Hold: q stays 0
+      tc({ s: false, r: false }, { q: false }),
+      // Set again: q becomes 1
+      tc({ s: true, r: false }, { q: true }),
+    ],
+    fixedCode: `VAR s BITIN
+VAR r BITIN
+VAR q BITOUT`,
+    editableCode: `# FLIPFLOPを使って回路を組み立ててください
+`,
+  },
 ];


### PR DESCRIPTION
## Summary
- `FlipflopModule` が `Program` の利用可能モジュールリストに未登録だったバグを修正
- Lv6 SR Latch パズルを追加（FLIPFLOPを使った状態遷移の問題）
- テストケースは順次実行で状態が引き継がれることを利用し、セット・保持・リセットの動作を検証

## Test plan
- [ ] Lv6で正しいコードを入力し全テスト通過を確認
- [ ] FLIPFLOP の状態がテストケース間で保持されることを確認
- [ ] Lv5クリア後にNext LevelでLv6に遷移できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)