### PR TITLE
Enhance test runner with circuit signal visualization

### DIFF
--- a/packages/language/src/internal-model/module.ts
+++ b/packages/language/src/internal-model/module.ts
@@ -170,7 +170,7 @@ export const createModule = (
         }
       }
 
-      return new Variable(varName, bitIns, bitOuts);
+      return new Variable(varName, bitIns, bitOuts, variables);
     }
   };
   Object.defineProperty(C, "name", { value: moduleStatement.name });

--- a/packages/language/src/internal-model/program.ts
+++ b/packages/language/src/internal-model/program.ts
@@ -29,4 +29,14 @@ export class Program {
 
     return outputSignals;
   }
+
+  public getAllSignals(): Map<string, boolean> {
+    const signals = new Map<string, boolean>();
+    for (const child of this.variable.children) {
+      for (const [portName, port] of child.outPorts.entries()) {
+        signals.set(`${child.name}.${portName}`, port.value);
+      }
+    }
+    return signals;
+  }
 }

--- a/packages/language/src/internal-model/variable.ts
+++ b/packages/language/src/internal-model/variable.ts
@@ -6,5 +6,6 @@ export class Variable {
     public readonly name: string,
     public readonly inPorts: Map<string, Reactive<boolean>>,
     public readonly outPorts: Map<string, Reactive<boolean>>,
+    public readonly children: Variable[] = [],
   ) {}
 }

--- a/packages/language/src/vm.ts
+++ b/packages/language/src/vm.ts
@@ -18,4 +18,9 @@ export class Vm {
     if (this.program == null) throw new Error(`No program compiled to run`);
     return this.program.run(inputSignals);
   }
+
+  public getAllSignals(): Map<string, boolean> {
+    if (this.program == null) throw new Error(`No program compiled`);
+    return this.program.getAllSignals();
+  }
 }

--- a/packages/language/tsconfig.json
+++ b/packages/language/tsconfig.json
@@ -3,17 +3,13 @@
     "target": "es2016",
     "lib": ["ES2023"],
     "module": "commonjs",
-    "rootDir": "src",
     "resolveJsonModule": true,
-    "outDir": "lib",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
-    "composite": true,
-    "declaration": true,
-    "declarationMap": true
+    "noEmit": true
   },
   "include": ["src"]
 }

--- a/packages/viewer/src/App.css
+++ b/packages/viewer/src/App.css
@@ -158,6 +158,16 @@
   cursor: default;
 }
 
+.step-btn {
+  background: #2d4a6a;
+  border-color: #3a6a9a;
+  color: #7db8ff;
+}
+
+.step-btn:hover:not(:disabled) {
+  background: #3a6a9a;
+}
+
 .run-btn {
   background: #2d6a30;
   border-color: #3a8a3e;

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
   const [currentLevel, setCurrentLevel] = useState(0);
   const currentPuzzle = puzzles[currentLevel];
 
-  const tc = useTestCases(compiledCode);
+  const tc = useTestCases(compiledCode, circuit.updateNodeSignals);
 
   const handleCompile = useCallback(
     (code: string) => {
@@ -81,6 +81,7 @@ function App() {
         inputNames={currentPuzzle.inputNames}
         outputNames={currentPuzzle.outputNames}
         onRunAll={tc.runAll}
+        onRunNext={tc.runNext}
         allPassed={tc.allPassed}
         onNextLevel={handleNextLevel}
         isLastLevel={currentLevel >= puzzles.length - 1}

--- a/packages/viewer/src/components/TestCasePanel.tsx
+++ b/packages/viewer/src/components/TestCasePanel.tsx
@@ -5,6 +5,7 @@ type Props = {
   inputNames: string[];
   outputNames: string[];
   onRunAll: () => void;
+  onRunNext: () => void;
   allPassed: boolean;
   onNextLevel: () => void;
   isLastLevel: boolean;
@@ -51,6 +52,7 @@ export function TestCasePanel({
   inputNames,
   outputNames,
   onRunAll,
+  onRunNext,
   allPassed,
   onNextLevel,
   isLastLevel,
@@ -62,6 +64,13 @@ export function TestCasePanel({
       <div className="test-case-header">
         <h3>Test Cases</h3>
         <div className="test-case-actions">
+          <button
+            className="action-btn step-btn"
+            onClick={onRunNext}
+            disabled={testCases.length === 0}
+          >
+            Step
+          </button>
           <button
             className="action-btn run-btn"
             onClick={onRunAll}

--- a/packages/viewer/src/components/nodes/BitinNode.tsx
+++ b/packages/viewer/src/components/nodes/BitinNode.tsx
@@ -7,7 +7,7 @@ export function BitinNode({ data }: NodeProps & { data: NodeData }) {
   return (
     <div className={`circuit-node bitin-node ${active ? "active" : ""}`}>
       <div className="node-label">{data.label}</div>
-      <div className="node-type">{active ? "ON" : "OFF"}</div>
+      <div className="node-type">{active ? "1" : "0"}</div>
       <Handle type="source" position={Position.Right} id="o0" />
     </div>
   );

--- a/packages/viewer/src/components/nodes/FlipflopNode.tsx
+++ b/packages/viewer/src/components/nodes/FlipflopNode.tsx
@@ -3,15 +3,16 @@ import type { NodeData } from "../../lib/astToGraph";
 import "./nodeStyles.css";
 
 export function FlipflopNode({ data }: NodeProps & { data: NodeData }) {
+  const q = data.value;
   return (
-    <div className="circuit-node flipflop-node">
+    <div className={`circuit-node flipflop-node ${q ? "active" : ""}`}>
       <Handle type="target" position={Position.Left} id="s" style={{ top: "30%" }} />
       <Handle type="target" position={Position.Left} id="r" style={{ top: "70%" }} />
       <div className="node-label">{data.label}</div>
       <div className="node-type">FLIPFLOP</div>
       <div style={{ display: "flex", justifyContent: "space-between", fontSize: 9, color: "#aaa" }}>
         <span>s/r</span>
-        <span>q</span>
+        <span>q={q !== undefined ? (q ? "1" : "0") : "?"}</span>
       </div>
       <Handle type="source" position={Position.Right} id="q" />
     </div>

--- a/packages/viewer/src/hooks/useCircuit.ts
+++ b/packages/viewer/src/hooks/useCircuit.ts
@@ -104,7 +104,11 @@ export function useCircuit() {
   );
 
   const updateNodeSignals = useCallback(
-    (inputs: Map<string, boolean>, outputs: Map<string, boolean>) => {
+    (
+      inputs: Map<string, boolean>,
+      outputs: Map<string, boolean>,
+      allSignals: Map<string, boolean>,
+    ) => {
       setNodes((prevNodes) =>
         prevNodes.map((node) => {
           if (node.data.moduleName === "BITIN") {
@@ -120,6 +124,18 @@ export function useCircuit() {
             };
           }
           return node;
+        }),
+      );
+      setEdges((prevEdges) =>
+        prevEdges.map((edge) => {
+          const key = `${edge.source}.${edge.sourceHandle}`;
+          const signal = allSignals.get(key);
+          if (signal === undefined) return edge;
+          return {
+            ...edge,
+            label: signal ? "1" : "0",
+            style: { stroke: signal ? "#4a9eff" : "#555" },
+          };
         }),
       );
     },

--- a/packages/viewer/src/hooks/useCircuit.ts
+++ b/packages/viewer/src/hooks/useCircuit.ts
@@ -123,6 +123,12 @@ export function useCircuit() {
               data: { ...node.data, value: outputs.get(node.id) ?? false },
             };
           }
+          if (node.data.moduleName === "FLIPFLOP") {
+            const q = allSignals.get(`${node.id}.q`);
+            if (q !== undefined) {
+              return { ...node, data: { ...node.data, value: q } };
+            }
+          }
           return node;
         }),
       );

--- a/packages/viewer/src/hooks/useCircuit.ts
+++ b/packages/viewer/src/hooks/useCircuit.ts
@@ -103,6 +103,29 @@ export function useCircuit() {
     [],
   );
 
+  const updateNodeSignals = useCallback(
+    (inputs: Map<string, boolean>, outputs: Map<string, boolean>) => {
+      setNodes((prevNodes) =>
+        prevNodes.map((node) => {
+          if (node.data.moduleName === "BITIN") {
+            return {
+              ...node,
+              data: { ...node.data, value: inputs.get(node.id) ?? false },
+            };
+          }
+          if (node.data.moduleName === "BITOUT") {
+            return {
+              ...node,
+              data: { ...node.data, value: outputs.get(node.id) ?? false },
+            };
+          }
+          return node;
+        }),
+      );
+    },
+    [],
+  );
+
   return {
     nodes,
     edges,
@@ -113,6 +136,7 @@ export function useCircuit() {
     error,
     compile,
     toggleInput,
+    updateNodeSignals,
     setNodes,
     setEdges,
   };

--- a/packages/viewer/src/hooks/useCircuit.ts
+++ b/packages/viewer/src/hooks/useCircuit.ts
@@ -133,8 +133,11 @@ export function useCircuit() {
           if (signal === undefined) return edge;
           return {
             ...edge,
-            label: signal ? "1" : "0",
-            style: { stroke: signal ? "#4a9eff" : "#555" },
+            style: {
+              stroke: signal ? "#4a9eff" : "#555",
+              strokeWidth: signal ? 2.5 : 1.5,
+              strokeDasharray: signal ? "none" : "5 3",
+            },
           };
         }),
       );

--- a/packages/viewer/src/hooks/useTestCases.ts
+++ b/packages/viewer/src/hooks/useTestCases.ts
@@ -9,7 +9,9 @@ export type TestCase = {
   status: "idle" | "pass" | "fail";
 };
 
-export function useTestCases(code: string | null) {
+type OnTestRun = (inputs: Map<string, boolean>, outputs: Map<string, boolean>) => void;
+
+export function useTestCases(code: string | null, onTestRun?: OnTestRun) {
   const [testCases, setTestCases] = useState<TestCase[]>([]);
   const vmRef = useRef<Vm | null>(null);
 
@@ -28,6 +30,9 @@ export function useTestCases(code: string | null) {
   const runVmRef = useRef<Vm | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const onTestRunRef = useRef(onTestRun);
+  onTestRunRef.current = onTestRun;
+
   const runStep = useCallback(() => {
     const idx = runIndexRef.current;
     const vm = runVmRef.current;
@@ -45,6 +50,8 @@ export function useTestCases(code: string | null) {
       );
       const result = [...prev];
       result[idx] = { ...tc, actualOutputs, status: pass ? "pass" : "fail" };
+
+      onTestRunRef.current?.(tc.inputs, actualOutputs);
 
       if (pass && idx + 1 < prev.length) {
         runIndexRef.current = idx + 1;
@@ -90,7 +97,62 @@ export function useTestCases(code: string | null) {
     }
   }, [code, runStep]);
 
+  const stepIndexRef = useRef<number>(0);
+  const stepVmRef = useRef<Vm | null>(null);
+
+  const runNext = useCallback(() => {
+    if (!code) return;
+    // First step: compile and reset
+    if (!stepVmRef.current) {
+      try {
+        const vm = new Vm();
+        vm.compile(code);
+        stepVmRef.current = vm;
+        stepIndexRef.current = 0;
+        setTestCases((prev) =>
+          prev.map((tc) => ({ ...tc, actualOutputs: null, status: "idle" as const })),
+        );
+      } catch {
+        setTestCases((prev) =>
+          prev.map((tc, i) =>
+            i === 0
+              ? { ...tc, actualOutputs: null, status: "fail" as const }
+              : tc,
+          ),
+        );
+        return;
+      }
+    }
+
+    const vm = stepVmRef.current;
+    const idx = stepIndexRef.current;
+
+    setTestCases((prev) => {
+      if (idx >= prev.length) return prev;
+      const tc = prev[idx];
+      const actualOutputs = vm.run(tc.inputs);
+      const pass = [...tc.expectedOutputs.entries()].every(
+        ([name, expected]) => actualOutputs.get(name) === expected,
+      );
+      const result = [...prev];
+      result[idx] = { ...tc, actualOutputs, status: pass ? "pass" : "fail" };
+
+      onTestRunRef.current?.(tc.inputs, actualOutputs);
+
+      if (pass && idx + 1 < prev.length) {
+        stepIndexRef.current = idx + 1;
+      } else {
+        // Stop on fail or completion
+        stepVmRef.current = null;
+      }
+
+      return result;
+    });
+  }, [code]);
+
   const resetResults = useCallback(() => {
+    stepVmRef.current = null;
+    stepIndexRef.current = 0;
     setTestCases((prev) =>
       prev.map((tc) => ({ ...tc, actualOutputs: null, status: "idle" as const })),
     );
@@ -103,6 +165,7 @@ export function useTestCases(code: string | null) {
     testCases,
     loadTestCases,
     runAll,
+    runNext,
     resetResults,
     allPassed,
   };

--- a/packages/viewer/src/hooks/useTestCases.ts
+++ b/packages/viewer/src/hooks/useTestCases.ts
@@ -9,7 +9,11 @@ export type TestCase = {
   status: "idle" | "pass" | "fail";
 };
 
-type OnTestRun = (inputs: Map<string, boolean>, outputs: Map<string, boolean>) => void;
+type OnTestRun = (
+  inputs: Map<string, boolean>,
+  outputs: Map<string, boolean>,
+  allSignals: Map<string, boolean>,
+) => void;
 
 export function useTestCases(code: string | null, onTestRun?: OnTestRun) {
   const [testCases, setTestCases] = useState<TestCase[]>([]);
@@ -51,7 +55,7 @@ export function useTestCases(code: string | null, onTestRun?: OnTestRun) {
       const result = [...prev];
       result[idx] = { ...tc, actualOutputs, status: pass ? "pass" : "fail" };
 
-      onTestRunRef.current?.(tc.inputs, actualOutputs);
+      onTestRunRef.current?.(tc.inputs, actualOutputs, vm.getAllSignals());
 
       if (pass && idx + 1 < prev.length) {
         runIndexRef.current = idx + 1;
@@ -137,7 +141,7 @@ export function useTestCases(code: string | null, onTestRun?: OnTestRun) {
       const result = [...prev];
       result[idx] = { ...tc, actualOutputs, status: pass ? "pass" : "fail" };
 
-      onTestRunRef.current?.(tc.inputs, actualOutputs);
+      onTestRunRef.current?.(tc.inputs, actualOutputs, vm.getAllSignals());
 
       if (pass && idx + 1 < prev.length) {
         stepIndexRef.current = idx + 1;

--- a/packages/viewer/src/language.d.ts
+++ b/packages/viewer/src/language.d.ts
@@ -2,6 +2,7 @@ declare module "@nandlang-ts/language/vm" {
   export class Vm {
     compile(programString: string): void;
     run(inputSignals: Map<string, boolean>): Map<string, boolean>;
+    getAllSignals(): Map<string, boolean>;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add step execution alongside Run All for test cases
- Reflect test execution state (0/1) on circuit diagram nodes (BITIN, BITOUT, FLIPFLOP)
- Display signal state on edges with visual styling (blue solid for 1, gray dashed for 0)
- Add `getAllSignals` API to language VM for internal wire signal access
- Remove unused build output settings from language tsconfig
- Change BITIN display from ON/OFF to 1/0

## Test plan
- [ ] Run All executes tests sequentially with node/edge signal updates
- [ ] Step button executes one test at a time with signal visualization
- [ ] Edges show blue solid lines for 1 and gray dashed lines for 0
- [ ] FLIPFLOP node displays internal state (q=0/q=1)
- [ ] SR Latch puzzle (Lv6) works correctly with sequential state

🤖 Generated with [Claude Code](https://claude.com/claude-code)