### PR TITLE
Fix fitView causing periodic UI stutter

### DIFF
--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -13,6 +13,7 @@ function App() {
   const circuit = useCircuit();
   const [compiledCode, setCompiledCode] = useState<string | null>(null);
   const [currentLevel, setCurrentLevel] = useState(0);
+  const [fitViewTrigger, setFitViewTrigger] = useState(0);
   const currentPuzzle = puzzles[currentLevel];
 
   const tc = useTestCases(compiledCode, circuit.updateNodeSignals);
@@ -21,6 +22,7 @@ function App() {
     (code: string) => {
       circuit.compile(code);
       setCompiledCode(code);
+      setFitViewTrigger((c) => c + 1);
       tc.resetResults();
     },
     [circuit, tc],
@@ -75,6 +77,7 @@ function App() {
         edges={circuit.edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        fitViewTrigger={fitViewTrigger}
       />
       <TestCasePanel
         testCases={tc.testCases}

--- a/packages/viewer/src/components/CircuitDiagramPanel.tsx
+++ b/packages/viewer/src/components/CircuitDiagramPanel.tsx
@@ -32,6 +32,7 @@ type Props = {
   edges: Edge[];
   onNodesChange: OnNodesChange;
   onEdgesChange: OnEdgesChange;
+  fitViewTrigger: number;
 };
 
 function CircuitDiagramInner({
@@ -39,13 +40,14 @@ function CircuitDiagramInner({
   edges,
   onNodesChange,
   onEdgesChange,
+  fitViewTrigger,
 }: Props) {
   const { fitView } = useReactFlow();
 
   useEffect(() => {
     const timer = setTimeout(() => fitView(), 50);
     return () => clearTimeout(timer);
-  }, [nodes, edges, fitView]);
+  }, [fitViewTrigger, fitView]);
 
   return (
     <ReactFlow


### PR DESCRIPTION
## Summary
- `fitView` was triggered on every `nodes`/`edges` change, causing a re-layout loop (~1s interval stutter)
- Changed to only trigger `fitView` on compile via an explicit counter

## Test plan
- [ ] No periodic UI stutter when idle or during test execution
- [ ] fitView still triggers correctly on Compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)