### PR TITLE
Add multi-page routing (Title, Level Select, Sandbox)

### DIFF
--- a/.claude/plans/20260309_multi_page_routing.md
+++ b/.claude/plans/20260309_multi_page_routing.md
@@ -1,0 +1,88 @@
+# マルチページ化（タイトル・レベル選択・レベル・サンドボックス）
+
+## Context
+
+現在の `packages/viewer` は単一ページのパズルゲーム。タイトル画面、レベル選択画面、サンドボックスモードを追加してゲームとしての体裁を整える。既存コンポーネントは既にゲームロジックとビューアロジックが分離されているため、1パッケージ内でページを追加する方針。
+
+## ルート設計
+
+| パス | コンポーネント | 説明 |
+|------|---------------|------|
+| `/` | `TitlePage` | タイトル、Puzzles/Sandboxへのリンク |
+| `/levels` | `LevelSelectPage` | パズル一覧グリッド |
+| `/level/:id` | `LevelPage` | パズルプレイ（現App.tsxの内容） |
+| `/sandbox` | `SandboxPage` | 自由編集＋回路可視化（テストなし） |
+
+Vercelデプロイのため `BrowserRouter` を使用（サーバーサイドリライト対応済み）。
+
+## 変更対象ファイル
+
+| ファイル | 操作 | 説明 |
+|---------|------|------|
+| `packages/viewer/package.json` | 変更 | `react-router-dom` 追加 |
+| `packages/viewer/index.html` | 変更 | title を "nandlang" に |
+| `packages/viewer/src/App.tsx` | 書き換え | ルーターシェルに |
+| `packages/viewer/src/components/CodeEditorPanel.tsx` | 変更 | `puzzle` propをオプショナル化 |
+| `packages/viewer/src/pages/TitlePage.tsx` | 新規 | タイトル画面 |
+| `packages/viewer/src/pages/TitlePage.css` | 新規 | タイトル画面スタイル |
+| `packages/viewer/src/pages/LevelSelectPage.tsx` | 新規 | レベル選択画面 |
+| `packages/viewer/src/pages/LevelSelectPage.css` | 新規 | レベル選択スタイル |
+| `packages/viewer/src/pages/LevelPage.tsx` | 新規 | 現App.tsxから抽出 |
+| `packages/viewer/src/pages/SandboxPage.tsx` | 新規 | サンドボックス画面 |
+| `packages/viewer/src/pages/SandboxPage.css` | 新規 | サンドボックススタイル |
+
+変更なし: `CircuitDiagramPanel`, `TestCasePanel`, `useCircuit`, `useTestCases`, `puzzles.ts`, 全ノードコンポーネント, `astToGraph.ts`
+
+## 実装ステップ
+
+### Step 1: react-router-dom 追加
+- `npm install react-router-dom -w @nandlang-ts/viewer`
+- **コミット: "Add react-router-dom dependency"**
+
+### Step 2: ルーター設定 + LevelPage抽出
+- `App.tsx` を `BrowserRouter` + `Routes` のルーターシェルに書き換え
+- 現 `App.tsx` の内容を `pages/LevelPage.tsx` に移動
+- `currentLevel` state → `useParams()` の `:id` に置換
+- `handleNextLevel` → `useNavigate()` で `/level/:nextId` へ遷移
+- `useEffect` で `id` パラメータ変更時にパズルをリロード（または `key={id}` で強制remount）
+- `index.html` の title 更新
+- この時点では `/` も `/levels` も `/sandbox` も `LevelPage` へリダイレクトで仮実装
+- **コミット: "Set up BrowserRouter and extract LevelPage"**
+
+### Step 3: TitlePage 作成
+- ゲームタイトル、キャッチコピー、Puzzles/Sandboxリンク
+- ダークテーマに合わせたスタイル
+- `/` ルートを TitlePage に差し替え
+- **コミット: "Add TitlePage"**
+
+### Step 4: LevelSelectPage 作成
+- `puzzles` をインポートしてカードグリッド表示
+- 各カードは `<Link to={/level/${puzzle.id}}>`
+- `/levels` ルートを差し替え
+- **コミット: "Add LevelSelectPage"**
+
+### Step 5: SandboxPage 作成
+- `CodeEditorPanel` の `puzzle` propをオプショナル化、`initialCode` prop追加
+  - puzzle無し時: タイトル/説明/fixedCode非表示、全体がテキストエリア
+- `SandboxPage`: `useCircuit` + `CircuitDiagramPanel` + `CodeEditorPanel`（puzzle無し）
+- テスト用パネルなし、2カラムレイアウト
+- `/sandbox` ルートを差し替え
+- **コミット: "Add SandboxPage with optional puzzle in CodeEditorPanel"**
+
+## 注意点
+
+- **ルート変更時のstate reset**: `/level/1` → `/level/2` で同コンポーネントが再利用される。`key={id}` をRoute elementに付与して強制remount で対応
+- **ReactFlowProvider**: `CircuitDiagramPanel` 内で自己完結しているため、SandboxPageでそのまま再利用可能
+- **パッケージ名変更**: スコープ外。別タスクとして実施可能
+
+## 検証方法
+
+1. `npm run dev` で起動
+2. `/` → タイトル画面表示、2つのリンクが機能する
+3. `/levels` → 6つのレベルカードが表示される
+4. カードクリック → `/level/1` でパズル画面に遷移、既存の動作が維持される
+5. パズルクリア → Next Level で `/level/2` に遷移
+6. `/sandbox` → テストパネルなしで自由にコード編集＋回路可視化
+7. ブラウザの戻る/進むが正しく動作する
+8. 不正なlevel ID（`/level/99`）が `/levels` にリダイレクトされる
+9. `npm run build` と `npm run lint` が成功する

--- a/package-lock.json
+++ b/package-lock.json
@@ -2263,6 +2263,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3393,6 +3406,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3474,6 +3525,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4040,7 +4097,8 @@
         "@xyflow/react": "^12.8.2",
         "dagre": "^0.8.5",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^7.13.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/packages/viewer/index.html
+++ b/packages/viewer/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>viewer</title>
+    <title>nandlang</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -15,7 +15,8 @@
     "@xyflow/react": "^12.8.2",
     "dagre": "^0.8.5",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate, useParams } from "react-router-dom";
 import { TitlePage } from "./pages/TitlePage";
+import { LevelSelectPage } from "./pages/LevelSelectPage";
 import { LevelPage } from "./pages/LevelPage";
 import "./App.css";
 
@@ -14,7 +15,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<TitlePage />} />
-        <Route path="/levels" element={<Navigate to="/level/1" replace />} />
+        <Route path="/levels" element={<LevelSelectPage />} />
         <Route path="/level/:id" element={<LevelPageWrapper />} />
         <Route path="/sandbox" element={<Navigate to="/level/1" replace />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -1,95 +1,24 @@
-import { useCallback, useEffect, useState } from "react";
-import { applyNodeChanges, applyEdgeChanges } from "@xyflow/react";
-import type { NodeChange, EdgeChange } from "@xyflow/react";
-import { CodeEditorPanel } from "./components/CodeEditorPanel";
-import { CircuitDiagramPanel } from "./components/CircuitDiagramPanel";
-import { TestCasePanel } from "./components/TestCasePanel";
-import { useCircuit } from "./hooks/useCircuit";
-import { useTestCases } from "./hooks/useTestCases";
-import { puzzles } from "./lib/puzzles";
+import { BrowserRouter, Routes, Route, Navigate, useParams } from "react-router-dom";
+import { LevelPage } from "./pages/LevelPage";
 import "./App.css";
 
+// key={id} forces remount when navigating between levels
+function LevelPageWrapper() {
+  const { id } = useParams<{ id: string }>();
+  return <LevelPage key={id} />;
+}
+
 function App() {
-  const circuit = useCircuit();
-  const [compiledCode, setCompiledCode] = useState<string | null>(null);
-  const [currentLevel, setCurrentLevel] = useState(0);
-  const [fitViewTrigger, setFitViewTrigger] = useState(0);
-  const currentPuzzle = puzzles[currentLevel];
-
-  const tc = useTestCases(compiledCode, circuit.updateNodeSignals);
-
-  const handleCompile = useCallback(
-    (code: string) => {
-      circuit.compile(code);
-      setCompiledCode(code);
-      setFitViewTrigger((c) => c + 1);
-      tc.resetResults();
-    },
-    [circuit, tc],
-  );
-
-  const handleLevelChange = useCallback(
-    (level: number) => {
-      setCurrentLevel(level);
-      const puzzle = puzzles[level];
-      tc.loadTestCases(puzzle.testCases);
-      handleCompile(`${puzzle.fixedCode}\n${puzzle.editableCode}`);
-    },
-    [tc, handleCompile],
-  );
-
-  const handleNextLevel = useCallback(() => {
-    if (currentLevel < puzzles.length - 1) {
-      handleLevelChange(currentLevel + 1);
-    }
-  }, [currentLevel, handleLevelChange]);
-
-  const onNodesChange = useCallback(
-    (changes: NodeChange[]) => {
-      circuit.setNodes((nds) => applyNodeChanges(changes, nds) as typeof nds);
-    },
-    [circuit],
-  );
-
-  const onEdgesChange = useCallback(
-    (changes: EdgeChange[]) => {
-      circuit.setEdges((eds) => applyEdgeChanges(changes, eds) as typeof eds);
-    },
-    [circuit],
-  );
-
-  // Auto-load first puzzle on mount
-  useEffect(() => {
-    tc.loadTestCases(currentPuzzle.testCases);
-    handleCompile(`${currentPuzzle.fixedCode}\n${currentPuzzle.editableCode}`);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
-    <div className="app-layout">
-      <CodeEditorPanel
-        onCompile={handleCompile}
-        error={circuit.error}
-        puzzle={currentPuzzle}
-      />
-      <CircuitDiagramPanel
-        nodes={circuit.nodes}
-        edges={circuit.edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        fitViewTrigger={fitViewTrigger}
-      />
-      <TestCasePanel
-        testCases={tc.testCases}
-        inputNames={currentPuzzle.inputNames}
-        outputNames={currentPuzzle.outputNames}
-        onRunAll={tc.runAll}
-        onRunNext={tc.runNext}
-        allPassed={tc.allPassed}
-        onNextLevel={handleNextLevel}
-        isLastLevel={currentLevel >= puzzles.length - 1}
-      />
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Navigate to="/level/1" replace />} />
+        <Route path="/levels" element={<Navigate to="/level/1" replace />} />
+        <Route path="/level/:id" element={<LevelPageWrapper />} />
+        <Route path="/sandbox" element={<Navigate to="/level/1" replace />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate, useParams } from "react-router-
 import { TitlePage } from "./pages/TitlePage";
 import { LevelSelectPage } from "./pages/LevelSelectPage";
 import { LevelPage } from "./pages/LevelPage";
+import { SandboxPage } from "./pages/SandboxPage";
 import "./App.css";
 
 // key={id} forces remount when navigating between levels
@@ -17,7 +18,7 @@ function App() {
         <Route path="/" element={<TitlePage />} />
         <Route path="/levels" element={<LevelSelectPage />} />
         <Route path="/level/:id" element={<LevelPageWrapper />} />
-        <Route path="/sandbox" element={<Navigate to="/level/1" replace />} />
+        <Route path="/sandbox" element={<SandboxPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate, useParams } from "react-router-dom";
+import { TitlePage } from "./pages/TitlePage";
 import { LevelPage } from "./pages/LevelPage";
 import "./App.css";
 
@@ -12,7 +13,7 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Navigate to="/level/1" replace />} />
+        <Route path="/" element={<TitlePage />} />
         <Route path="/levels" element={<Navigate to="/level/1" replace />} />
         <Route path="/level/:id" element={<LevelPageWrapper />} />
         <Route path="/sandbox" element={<Navigate to="/level/1" replace />} />

--- a/packages/viewer/src/components/CodeEditorPanel.tsx
+++ b/packages/viewer/src/components/CodeEditorPanel.tsx
@@ -1,28 +1,34 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import type { Puzzle } from "../lib/puzzles";
 
 type Props = {
   onCompile: (code: string) => void;
   error: string | null;
-  puzzle: Puzzle;
+  puzzle?: Puzzle;
+  initialCode?: string;
 };
 
-export function CodeEditorPanel({ onCompile, error, puzzle }: Props) {
-  const [code, setCode] = useState(puzzle.editableCode);
+export function CodeEditorPanel({ onCompile, error, puzzle, initialCode = "" }: Props) {
+  const [code, setCode] = useState(puzzle?.editableCode ?? initialCode);
 
-  useEffect(() => {
-    setCode(puzzle.editableCode);
-  }, [puzzle]);
-
-  const fullCode = `${puzzle.fixedCode}\n${code}`;
+  const fullCode = puzzle ? `${puzzle.fixedCode}\n${code}` : code;
 
   return (
     <div className="code-editor-panel">
-      <div className="panel-header">
-        <h3>{puzzle.title}</h3>
-      </div>
-      <div className="puzzle-description">{puzzle.description}</div>
-      <pre className="fixed-code">{puzzle.fixedCode}</pre>
+      {puzzle && (
+        <>
+          <div className="panel-header">
+            <h3>{puzzle.title}</h3>
+          </div>
+          <div className="puzzle-description">{puzzle.description}</div>
+          <pre className="fixed-code">{puzzle.fixedCode}</pre>
+        </>
+      )}
+      {!puzzle && (
+        <div className="panel-header">
+          <h3>Sandbox</h3>
+        </div>
+      )}
       <textarea
         value={code}
         onChange={(e) => setCode(e.target.value)}

--- a/packages/viewer/src/pages/LevelPage.tsx
+++ b/packages/viewer/src/pages/LevelPage.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams, useNavigate, Navigate } from "react-router-dom";
+import { applyNodeChanges, applyEdgeChanges } from "@xyflow/react";
+import type { NodeChange, EdgeChange } from "@xyflow/react";
+import { CodeEditorPanel } from "../components/CodeEditorPanel";
+import { CircuitDiagramPanel } from "../components/CircuitDiagramPanel";
+import { TestCasePanel } from "../components/TestCasePanel";
+import { useCircuit } from "../hooks/useCircuit";
+import { useTestCases } from "../hooks/useTestCases";
+import { puzzles } from "../lib/puzzles";
+
+export function LevelPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const levelIndex = useMemo(
+    () => puzzles.findIndex((p) => p.id === Number(id)),
+    [id],
+  );
+  const currentPuzzle = levelIndex !== -1 ? puzzles[levelIndex] : null;
+
+  const circuit = useCircuit();
+  const [compiledCode, setCompiledCode] = useState<string | null>(null);
+  const [fitViewTrigger, setFitViewTrigger] = useState(0);
+
+  const tc = useTestCases(compiledCode, circuit.updateNodeSignals);
+
+  const handleCompile = useCallback(
+    (code: string) => {
+      circuit.compile(code);
+      setCompiledCode(code);
+      setFitViewTrigger((c) => c + 1);
+      tc.resetResults();
+    },
+    [circuit, tc],
+  );
+
+  const handleNextLevel = useCallback(() => {
+    if (levelIndex < puzzles.length - 1) {
+      const nextPuzzle = puzzles[levelIndex + 1];
+      navigate(`/level/${nextPuzzle.id}`);
+    }
+  }, [levelIndex, navigate]);
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      circuit.setNodes((nds) => applyNodeChanges(changes, nds) as typeof nds);
+    },
+    [circuit],
+  );
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => {
+      circuit.setEdges((eds) => applyEdgeChanges(changes, eds) as typeof eds);
+    },
+    [circuit],
+  );
+
+  // Auto-load puzzle on mount
+  useEffect(() => {
+    if (!currentPuzzle) return;
+    tc.loadTestCases(currentPuzzle.testCases);
+    handleCompile(`${currentPuzzle.fixedCode}\n${currentPuzzle.editableCode}`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!currentPuzzle) {
+    return <Navigate to="/levels" replace />;
+  }
+
+  return (
+    <div className="app-layout">
+      <CodeEditorPanel
+        onCompile={handleCompile}
+        error={circuit.error}
+        puzzle={currentPuzzle}
+      />
+      <CircuitDiagramPanel
+        nodes={circuit.nodes}
+        edges={circuit.edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        fitViewTrigger={fitViewTrigger}
+      />
+      <TestCasePanel
+        testCases={tc.testCases}
+        inputNames={currentPuzzle.inputNames}
+        outputNames={currentPuzzle.outputNames}
+        onRunAll={tc.runAll}
+        onRunNext={tc.runNext}
+        allPassed={tc.allPassed}
+        onNextLevel={handleNextLevel}
+        isLastLevel={levelIndex >= puzzles.length - 1}
+      />
+    </div>
+  );
+}

--- a/packages/viewer/src/pages/LevelSelectPage.css
+++ b/packages/viewer/src/pages/LevelSelectPage.css
@@ -1,0 +1,68 @@
+.level-select-page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 32px 24px;
+}
+
+.level-select-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.level-select-header h1 {
+  margin: 0;
+  font-size: 28px;
+  color: #eee;
+}
+
+.back-link {
+  color: #888;
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.back-link:hover {
+  color: #ccc;
+}
+
+.level-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.level-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px;
+  background: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.level-card:hover {
+  border-color: #4a9eff;
+  background: #333;
+}
+
+.level-card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #eee;
+}
+
+.level-card-desc {
+  font-size: 13px;
+  color: #999;
+  line-height: 1.4;
+  white-space: pre-line;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/packages/viewer/src/pages/LevelSelectPage.tsx
+++ b/packages/viewer/src/pages/LevelSelectPage.tsx
@@ -1,0 +1,28 @@
+import { Link } from "react-router-dom";
+import { puzzles } from "../lib/puzzles";
+import "./LevelSelectPage.css";
+
+export function LevelSelectPage() {
+  return (
+    <div className="level-select-page">
+      <div className="level-select-header">
+        <Link to="/" className="back-link">
+          &larr; Back
+        </Link>
+        <h1>Puzzles</h1>
+      </div>
+      <div className="level-grid">
+        {puzzles.map((puzzle) => (
+          <Link
+            key={puzzle.id}
+            to={`/level/${puzzle.id}`}
+            className="level-card"
+          >
+            <span className="level-card-title">{puzzle.title}</span>
+            <span className="level-card-desc">{puzzle.description}</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/viewer/src/pages/SandboxPage.css
+++ b/packages/viewer/src/pages/SandboxPage.css
@@ -1,0 +1,30 @@
+.sandbox-layout {
+  display: grid;
+  grid-template-columns: 350px 1fr;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+.sandbox-sidebar {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid #444;
+  overflow-y: auto;
+}
+
+.sandbox-sidebar .back-link {
+  padding: 12px 16px 0;
+  color: #888;
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.sandbox-sidebar .back-link:hover {
+  color: #ccc;
+}
+
+.sandbox-sidebar .code-editor-panel {
+  flex: 1;
+  border-right: none;
+}

--- a/packages/viewer/src/pages/SandboxPage.tsx
+++ b/packages/viewer/src/pages/SandboxPage.tsx
@@ -1,0 +1,66 @@
+import { useCallback, useState } from "react";
+import { Link } from "react-router-dom";
+import { applyNodeChanges, applyEdgeChanges } from "@xyflow/react";
+import type { NodeChange, EdgeChange } from "@xyflow/react";
+import { CodeEditorPanel } from "../components/CodeEditorPanel";
+import { CircuitDiagramPanel } from "../components/CircuitDiagramPanel";
+import { useCircuit } from "../hooks/useCircuit";
+import "./SandboxPage.css";
+
+const DEFAULT_CODE = `VAR a BITIN
+VAR b BITIN
+VAR out BITOUT
+VAR nand NAND
+WIRE a _ TO nand i0
+WIRE b _ TO nand i1
+WIRE nand _ TO out _
+`;
+
+export function SandboxPage() {
+  const circuit = useCircuit();
+  const [fitViewTrigger, setFitViewTrigger] = useState(0);
+
+  const handleCompile = useCallback(
+    (code: string) => {
+      circuit.compile(code);
+      setFitViewTrigger((c) => c + 1);
+    },
+    [circuit],
+  );
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) => {
+      circuit.setNodes((nds) => applyNodeChanges(changes, nds) as typeof nds);
+    },
+    [circuit],
+  );
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) => {
+      circuit.setEdges((eds) => applyEdgeChanges(changes, eds) as typeof eds);
+    },
+    [circuit],
+  );
+
+  return (
+    <div className="sandbox-layout">
+      <div className="sandbox-sidebar">
+        <Link to="/" className="back-link">
+          &larr; Back
+        </Link>
+        <CodeEditorPanel
+          onCompile={handleCompile}
+          error={circuit.error}
+          initialCode={DEFAULT_CODE}
+        />
+      </div>
+      <CircuitDiagramPanel
+        nodes={circuit.nodes}
+        edges={circuit.edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        fitViewTrigger={fitViewTrigger}
+      />
+    </div>
+  );
+}

--- a/packages/viewer/src/pages/TitlePage.css
+++ b/packages/viewer/src/pages/TitlePage.css
@@ -1,0 +1,61 @@
+.title-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100vw;
+}
+
+.title-content {
+  text-align: center;
+}
+
+.title-logo {
+  font-size: 64px;
+  font-weight: 800;
+  letter-spacing: -2px;
+  color: #eee;
+  margin: 0 0 12px;
+  font-family: "Fira Code", "Cascadia Code", "Consolas", monospace;
+}
+
+.title-tagline {
+  font-size: 18px;
+  color: #888;
+  margin: 0 0 48px;
+}
+
+.title-nav {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+}
+
+.title-link {
+  display: inline-block;
+  padding: 14px 36px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.title-link-primary {
+  background: #4a9eff;
+  color: #fff;
+}
+
+.title-link-primary:hover {
+  background: #3a8eef;
+}
+
+.title-link-secondary {
+  background: #333;
+  color: #ccc;
+  border: 1px solid #555;
+}
+
+.title-link-secondary:hover {
+  background: #444;
+}

--- a/packages/viewer/src/pages/TitlePage.tsx
+++ b/packages/viewer/src/pages/TitlePage.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+import "./TitlePage.css";
+
+export function TitlePage() {
+  return (
+    <div className="title-page">
+      <div className="title-content">
+        <h1 className="title-logo">nandlang</h1>
+        <p className="title-tagline">
+          Build logic from nothing but NAND gates.
+        </p>
+        <nav className="title-nav">
+          <Link to="/levels" className="title-link title-link-primary">
+            Puzzles
+          </Link>
+          <Link to="/sandbox" className="title-link title-link-secondary">
+            Sandbox
+          </Link>
+        </nav>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- react-router-dom を導入し、BrowserRouter ベースのマルチページ構成を実装
- TitlePage (`/`), LevelSelectPage (`/levels`), LevelPage (`/level/:id`), SandboxPage (`/sandbox`) の4ページを追加
- 既存の App.tsx のパズルロジックを LevelPage に抽出し、CodeEditorPanel の puzzle prop をオプショナル化してサンドボックスでも再利用可能に

## Test plan
- [x] `/` にタイトル画面が表示され、Puzzles/Sandbox リンクが機能する
- [x] `/levels` に6つのレベルカードがグリッド表示される
- [x] `/level/1` でパズル画面（コードエディタ・回路図・テストパネル）が表示される
- [x] `/sandbox` でテストパネルなしの自由編集+回路可視化が動作する
- [x] 不正な level ID (`/level/99`) が `/levels` にリダイレクトされる
- [x] ブラウザの戻る/進むが正しく動作する
- [x] `npm run build` が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)