### PR TITLE
Rename Compile & Run to Compile, disable tests until compiled

### DIFF
--- a/packages/viewer/src/components/CodeEditorPanel.tsx
+++ b/packages/viewer/src/components/CodeEditorPanel.tsx
@@ -3,13 +3,19 @@ import type { Puzzle } from "../lib/puzzles";
 
 type Props = {
   onCompile: (code: string) => void;
+  onDirty?: () => void;
   error: string | null;
   puzzle?: Puzzle;
   initialCode?: string;
 };
 
-export function CodeEditorPanel({ onCompile, error, puzzle, initialCode = "" }: Props) {
+export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode = "" }: Props) {
   const [code, setCode] = useState(puzzle?.editableCode ?? initialCode);
+
+  const handleChange = (value: string) => {
+    setCode(value);
+    onDirty?.();
+  };
 
   const fullCode = puzzle ? `${puzzle.fixedCode}\n${code}` : code;
 
@@ -31,11 +37,11 @@ export function CodeEditorPanel({ onCompile, error, puzzle, initialCode = "" }: 
       )}
       <textarea
         value={code}
-        onChange={(e) => setCode(e.target.value)}
+        onChange={(e) => handleChange(e.target.value)}
         spellCheck={false}
       />
       <button className="compile-btn" onClick={() => onCompile(fullCode)}>
-        Compile & Run
+        Compile
       </button>
       {error && <div className="error-display">{error}</div>}
     </div>

--- a/packages/viewer/src/components/TestCasePanel.tsx
+++ b/packages/viewer/src/components/TestCasePanel.tsx
@@ -9,6 +9,7 @@ type Props = {
   allPassed: boolean;
   onNextLevel: () => void;
   isLastLevel: boolean;
+  disabled?: boolean;
 };
 
 function StatusBadge({ status }: { status: TestCase["status"] }) {
@@ -56,6 +57,7 @@ export function TestCasePanel({
   allPassed,
   onNextLevel,
   isLastLevel,
+  disabled = false,
 }: Props) {
   if (inputNames.length === 0 && outputNames.length === 0) return null;
 
@@ -67,14 +69,14 @@ export function TestCasePanel({
           <button
             className="action-btn step-btn"
             onClick={onRunNext}
-            disabled={testCases.length === 0}
+            disabled={disabled || testCases.length === 0}
           >
             Step
           </button>
           <button
             className="action-btn run-btn"
             onClick={onRunAll}
-            disabled={testCases.length === 0}
+            disabled={disabled || testCases.length === 0}
           >
             Run All
           </button>

--- a/packages/viewer/src/pages/LevelPage.tsx
+++ b/packages/viewer/src/pages/LevelPage.tsx
@@ -21,6 +21,7 @@ export function LevelPage() {
   const circuit = useCircuit();
   const [compiledCode, setCompiledCode] = useState<string | null>(null);
   const [fitViewTrigger, setFitViewTrigger] = useState(0);
+  const [dirty, setDirty] = useState(false);
 
   const tc = useTestCases(compiledCode, circuit.updateNodeSignals);
 
@@ -29,6 +30,7 @@ export function LevelPage() {
       circuit.compile(code);
       setCompiledCode(code);
       setFitViewTrigger((c) => c + 1);
+      setDirty(false);
       tc.resetResults();
     },
     [circuit, tc],
@@ -71,6 +73,7 @@ export function LevelPage() {
     <div className="app-layout">
       <CodeEditorPanel
         onCompile={handleCompile}
+        onDirty={() => setDirty(true)}
         error={circuit.error}
         puzzle={currentPuzzle}
       />
@@ -90,6 +93,7 @@ export function LevelPage() {
         allPassed={tc.allPassed}
         onNextLevel={handleNextLevel}
         isLastLevel={levelIndex >= puzzles.length - 1}
+        disabled={dirty}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- ボタンラベルを「Compile & Run」から「Compile」に変更（実態に合わせた表記）
- エディタ変更時にテストボタン（Step / Run All）を無効化し、Compile後に再有効化
- CodeEditorPanel に `onDirty` コールバック、TestCasePanel に `disabled` prop を追加

## Test plan
- [x] ボタン表示が「Compile」になっている
- [x] 初期ロード後（自動コンパイル済み）はテストボタンが有効
- [x] エディタを編集するとテストボタンが無効化される
- [x] Compileボタン押下後にテストボタンが再度有効化される
- [x] Sandboxページでもボタン表示が「Compile」になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)