### PR TITLE
Improve puzzle UI and move module definitions to fixedCode

### DIFF
--- a/packages/viewer/src/App.css
+++ b/packages/viewer/src/App.css
@@ -308,28 +308,13 @@
   white-space: pre-line;
 }
 
-/* Success banner */
-.success-banner {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 14px;
-  margin-bottom: 8px;
-  background: #1a3a1a;
-  border: 1px solid #3a8a3e;
-  border-radius: 6px;
-  color: #7dff82;
-  font-size: 14px;
-  font-weight: 600;
-}
-
 .next-level-btn {
-  padding: 6px 16px;
+  padding: 4px 12px;
   background: #4a9eff;
   color: white;
-  border: none;
+  border: 1px solid #3a8eef;
   border-radius: 4px;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   cursor: pointer;
 }

--- a/packages/viewer/src/components/TestCasePanel.tsx
+++ b/packages/viewer/src/components/TestCasePanel.tsx
@@ -80,18 +80,13 @@ export function TestCasePanel({
           >
             Run All
           </button>
-        </div>
-      </div>
-      {allPassed && (
-        <div className="success-banner">
-          All tests passed!
-          {!isLastLevel && (
+          {allPassed && !isLastLevel && (
             <button className="next-level-btn" onClick={onNextLevel}>
               Next Level &rarr;
             </button>
           )}
         </div>
-      )}
+      </div>
       {testCases.length === 0 ? (
         <p className="empty-message">No test cases.</p>
       ) : (

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -37,9 +37,9 @@ export const puzzles: Puzzle[] = [
       tc({ a: true }, { out: false }),
     ],
     fixedCode: `VAR a BITIN
-VAR out BITOUT`,
-    editableCode: `VAR nand NAND
-WIRE a _ TO nand i0
+VAR out BITOUT
+VAR nand NAND`,
+    editableCode: `WIRE a _ TO nand i0
 WIRE a _ TO nand i1
 WIRE nand _ TO out _
 `,
@@ -59,11 +59,11 @@ WIRE nand _ TO out _
     ],
     fixedCode: `VAR a BITIN
 VAR b BITIN
-VAR out BITOUT`,
-    editableCode: `VAR nand NAND
-WIRE a _ TO nand i0
+VAR out BITOUT
+VAR nand NAND
+VAR n2 NAND`,
+    editableCode: `WIRE a _ TO nand i0
 WIRE b _ TO nand i1
-VAR n2 NAND
 WIRE nand _ TO n2 i0
 WIRE nand _ TO n2 i1
 WIRE n2 _ TO out _
@@ -84,14 +84,14 @@ WIRE n2 _ TO out _
     ],
     fixedCode: `VAR a BITIN
 VAR b BITIN
-VAR out BITOUT`,
-    editableCode: `VAR na NAND
-WIRE a _ TO na i0
-WIRE a _ TO na i1
+VAR out BITOUT
+VAR na NAND
 VAR nb NAND
+VAR nand NAND`,
+    editableCode: `WIRE a _ TO na i0
+WIRE a _ TO na i1
 WIRE b _ TO nb i0
 WIRE b _ TO nb i1
-VAR nand NAND
 WIRE na _ TO nand i0
 WIRE nb _ TO nand i1
 WIRE nand _ TO out _
@@ -112,17 +112,17 @@ WIRE nand _ TO out _
     ],
     fixedCode: `VAR a BITIN
 VAR b BITIN
-VAR out BITOUT`,
-    editableCode: `VAR na NAND
-WIRE a _ TO na i0
-WIRE a _ TO na i1
+VAR out BITOUT
+VAR na NAND
 VAR nb NAND
+VAR or NAND
+VAR not NAND`,
+    editableCode: `WIRE a _ TO na i0
+WIRE a _ TO na i1
 WIRE b _ TO nb i0
 WIRE b _ TO nb i1
-VAR or NAND
 WIRE na _ TO or i0
 WIRE nb _ TO or i1
-VAR not NAND
 WIRE or _ TO not i0
 WIRE or _ TO not i1
 WIRE not _ TO out _
@@ -143,17 +143,17 @@ WIRE not _ TO out _
     ],
     fixedCode: `VAR a BITIN
 VAR b BITIN
-VAR out BITOUT`,
-    editableCode: `VAR nand NAND
-WIRE a _ TO nand i0
-WIRE b _ TO nand i1
+VAR out BITOUT
+VAR nand NAND
 VAR n1 NAND
+VAR n2 NAND
+VAR n3 NAND`,
+    editableCode: `WIRE a _ TO nand i0
+WIRE b _ TO nand i1
 WIRE a _ TO n1 i0
 WIRE nand _ TO n1 i1
-VAR n2 NAND
 WIRE nand _ TO n2 i0
 WIRE b _ TO n2 i1
-VAR n3 NAND
 WIRE n1 _ TO n3 i0
 WIRE n2 _ TO n3 i1
 WIRE n3 _ TO out _
@@ -182,9 +182,9 @@ WIRE n3 _ TO out _
     ],
     fixedCode: `VAR s BITIN
 VAR r BITIN
-VAR q BITOUT`,
-    editableCode: `VAR ff FLIPFLOP
-WIRE s _ TO ff s
+VAR q BITOUT
+VAR ff FLIPFLOP`,
+    editableCode: `WIRE s _ TO ff s
 WIRE r _ TO ff r
 WIRE ff _ TO q _
 `,


### PR DESCRIPTION
## Summary
- "All tests passed" バナーを削除し、Next Level ボタンを Run All の隣に配置
- 各レベルのモジュール定義（VAR ... NAND/FLIPFLOP）を fixedCode に移動し、editableCode は WIRE 文のみに
- Next Level ボタンのサイズを他のアクションボタンと統一

## Test plan
- [x] language パッケージのテスト全通過（74 tests）
- [x] viewer パッケージのビルド成功
- [ ] 各レベルで Compile → Run All が正常動作することを確認
- [ ] 全テスト通過時に Next Level ボタンが Run All の隣に表示されることを確認
- [ ] fixedCode 部分が読み取り専用で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)