### PR TITLE
Redesign puzzles: 10-level progression with module unlock system

### DIFF
--- a/.claude/plans/20260310_redesign_puzzle_levels.md
+++ b/.claude/plans/20260310_redesign_puzzle_levels.md
@@ -1,0 +1,196 @@
+# レベルデザイン: 基礎ゲート編 (Lv1〜10)
+
+## Context
+
+現在6レベル（NOT, AND, OR, NOR, XOR, SR Latch）が存在するが、チュートリアル要素がなく、モジュール解放システムもない。レベルを再設計し、ワイヤリングの基礎から段階的に学べる10レベル構成にする。クリアしたゲートはモジュールとして後続レベルで使用可能になる。SR LatchとFLIPFLOPは後続の数値演算編で扱う。
+
+## 設計方針
+
+- **自由記述方式**: fixedCodeにはBITIN/BITOUTのみ宣言。ユーザーがVAR宣言もWIRE文も自由に書く
+- **モジュール解放**: レベルクリア時にそのゲートがモジュールとして使えるようになる
+- **解放モジュールのMOD定義**: fixedCodeにMOD定義を含めてコンパイル可能にする（表示上は隠す）
+
+## レベル一覧
+
+| Lv | タイトル | 目的 | 使用可能モジュール | 解放モジュール |
+|----|---------|------|-------------------|--------------|
+| 1 | Wire | 結線方法を学ぶ（パススルー） | - | - |
+| 2 | NAND | NANDの動作を知る | - | - |
+| 3 | NOT | NANDからNOTを作る | - | NOT |
+| 4 | AND | ANDゲートを作る | NOT | AND |
+| 5 | OR | ORゲートを作る | NOT | OR |
+| 6 | NOR | NORゲートを作る | NOT, AND, OR | NOR |
+| 7 | XOR | XORゲートを作る | NOT, AND, OR, NOR | XOR |
+| 8 | XNOR | XNORゲートを作る | NOT〜XOR | XNOR |
+| 9 | AND3 | 3入力ANDを作る | NOT〜XNOR | AND3 |
+| 10 | OR3 | 3入力ORを作る | NOT〜AND3 | OR3 |
+
+## 各レベル詳細設計
+
+### Lv1: Wire（パススルー）
+- **説明**: 入力aをそのまま出力outに接続してください。\nWIRE文で変数同士を結線します。
+- **fixedCode**: `VAR a BITIN\nVAR out BITOUT`
+- **テスト**: `a=0→out=0`, `a=1→out=1`
+- **editableCode**: 空
+
+### Lv2: NAND
+- **説明**: 2つの入力をNANDゲートに接続し、結果をoutに出力してください。\nVAR文で変数を宣言し、WIRE文で結線します。
+- **fixedCode**: `VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`
+- **テスト**: 4パターンの真理値表
+- **editableCode**: 空（ユーザーが `VAR nand NAND` + WIRE文を書く）
+
+### Lv3: NOT
+- **説明**: NANDゲートを使って入力aの反転をoutに出力してください。
+- **fixedCode**: `VAR a BITIN\nVAR out BITOUT`
+- **テスト**: `a=0→out=1`, `a=1→out=0`
+- **解放**: NOT モジュール
+
+### Lv4: AND
+- **説明**: aとbの両方が1のときだけoutが1になる回路を作ってください。
+- **fixedCode**: BITIN x2 + BITOUT + NOTのMOD定義
+- **テスト**: 4パターン
+- **解放**: AND モジュール
+
+### Lv5: OR
+- **説明**: aまたはbのどちらかが1ならoutが1になる回路を作ってください。
+- **fixedCode**: BITIN x2 + BITOUT + NOTのMOD定義
+- **テスト**: 4パターン
+- **解放**: OR モジュール
+
+### Lv6: NOR
+- **説明**: aとbの両方が0のときだけoutが1になる回路を作ってください。
+- **fixedCode**: BITIN x2 + BITOUT + NOT/AND/ORのMOD定義
+- **テスト**: 4パターン
+- **解放**: NOR モジュール
+
+### Lv7: XOR
+- **説明**: aとbが異なるときだけoutが1になる回路を作ってください。
+- **fixedCode**: BITIN x2 + BITOUT + NOT〜NORのMOD定義
+- **テスト**: 4パターン
+- **解放**: XOR モジュール
+
+### Lv8: XNOR
+- **説明**: aとbが同じときだけoutが1になる回路を作ってください。
+- **fixedCode**: BITIN x2 + BITOUT + NOT〜XORのMOD定義
+- **テスト**: 4パターン
+- **解放**: XNOR モジュール
+
+### Lv9: AND3
+- **説明**: 3つの入力a,b,cすべてが1のときだけoutが1になる回路を作ってください。
+- **fixedCode**: BITIN x3 + BITOUT + NOT〜XNORのMOD定義
+- **テスト**: 8パターン（3ビット全組み合わせ）
+- **解放**: AND3 モジュール
+
+### Lv10: OR3
+- **説明**: 3つの入力a,b,cのいずれかが1ならoutが1になる回路を作ってください。
+- **fixedCode**: BITIN x3 + BITOUT + NOT〜AND3のMOD定義
+- **テスト**: 8パターン（3ビット全組み合わせ）
+- **解放**: OR3 モジュール
+
+## 実装変更
+
+### 1. Puzzle型の拡張 (`packages/viewer/src/lib/puzzles.ts`)
+
+```typescript
+export type Puzzle = {
+  id: number;
+  title: string;
+  description: string;
+  inputNames: string[];
+  outputNames: string[];
+  testCases: PuzzleTestCase[];
+  fixedCode: string;       // コンパイル用（MOD定義+BITIN/BITOUT宣言）
+  editableCode: string;    // 空文字列（ユーザーがVAR+WIREを自由に記述）
+  unlocksModule?: string;  // クリア時に解放されるモジュール名
+  availableModules?: string[]; // このレベルで使用可能な解放済みモジュール名リスト
+};
+```
+
+- puzzles配列を10レベルに書き換え（SR Latch除外）
+- fixedCodeにはMOD定義を含める（コンパイルに必要）
+- 各レベルのMOD定義は `@nandlang-ts/language` の code-fragments.ts からimport
+- editableCodeは全レベルで空文字列
+
+### 2. fixedCode内のMOD定義の表示 (`packages/viewer/src/components/CodeEditorPanel.tsx`)
+
+fixedCodeにMOD定義が含まれると長大になるため、表示を工夫する:
+- MOD START〜MOD END ブロックは非表示にし、VAR行のみ表示
+- `availableModules`がある場合、「利用可能モジュール: NOT, AND, ...」ラベルを表示
+- 詳細を見たい場合は折りたたみで展開可能
+
+### 3. 進捗管理 (`packages/viewer/src/lib/progress.ts` - 新規)
+
+```typescript
+const STORAGE_KEY = "nandlang-progress";
+type ProgressData = { completedLevels: number[] };
+
+export function getProgress(): ProgressData;
+export function markLevelCompleted(puzzleId: number): ProgressData;
+export function isLevelUnlocked(puzzleId: number, puzzles: Puzzle[], progress: ProgressData): boolean;
+export function getUnlockedModules(puzzles: Puzzle[], progress: ProgressData): string[];
+export function resetProgress(): void;
+```
+
+- Lv1は常にアンロック
+- Lv Nは Lv N-1がcompletedLevelsに含まれていればアンロック
+- 解放済みモジュール = completedLevelsに含まれるパズルの`unlocksModule`を収集
+
+### 4. LevelSelectPage更新 (`packages/viewer/src/pages/LevelSelectPage.tsx`)
+
+- ロック済みレベルはグレーアウト（クリック不可）
+- クリア済みレベルにはチェックマーク表示
+- 進捗リセットボタン追加
+
+### 5. LevelPage更新 (`packages/viewer/src/pages/LevelPage.tsx`)
+
+- 全テスト通過時に `markLevelCompleted` を呼ぶ
+- モジュール解放時に通知メッセージ表示（例: 「NOT モジュールが解放されました！」）
+- ロック済みレベルへのアクセスは `/levels` にリダイレクト
+
+### 6. fixedCodeの構成方針
+
+**自由記述方式**: fixedCodeにはBITIN/BITOUT宣言 + 解放済みモジュールのMOD定義のみ。ユーザーがVAR宣言（NANDや解放済みモジュールの使用）とWIRE文を自由に記述する。
+
+例（Lv4 AND）:
+```
+# fixedCode (コンパイル用全文)
+MOD START NOT
+  VAR in BITIN
+  VAR nand NAND
+  WIRE in _ TO nand i0
+  WIRE in _ TO nand i1
+  VAR out BITOUT
+  WIRE nand _ TO out _
+MOD END
+VAR a BITIN
+VAR b BITIN
+VAR out BITOUT
+```
+
+表示上はMOD定義を隠し:
+```
+利用可能モジュール: NAND, NOT
+VAR a BITIN
+VAR b BITIN
+VAR out BITOUT
+```
+
+ユーザーが書く例:
+```
+VAR nand NAND
+VAR not NOT
+WIRE a _ TO nand i0
+WIRE b _ TO nand i1
+WIRE nand _ TO not _
+WIRE not _ TO out _
+```
+
+## 検証方法
+
+1. `npm run dev` でviewerを起動
+2. Lv1から順にプレイして各レベルの真理値表テストが通ることを確認
+3. レベルクリア後にモジュールが解放されることを確認
+4. 次レベルがアンロックされることを確認
+5. ロック済みレベルにアクセスできないことを確認
+6. ブラウザリロード後も進捗が保持されることを確認
+7. 既存のユニットテスト（`npm test -w packages/language`）がパスすることを確認

--- a/packages/viewer/src/App.css
+++ b/packages/viewer/src/App.css
@@ -322,3 +322,74 @@
 .next-level-btn:hover {
   background: #3a8eef;
 }
+
+/* Available modules label */
+.available-modules {
+  margin-bottom: 8px;
+  padding: 6px 10px;
+  background: #1a2a1a;
+  border: 1px solid #3a5a3a;
+  border-radius: 6px;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.available-modules-label {
+  color: #7dff82;
+  font-weight: 600;
+}
+
+.available-modules-list {
+  color: #aad4ab;
+  font-family: monospace;
+}
+
+.mod-details-toggle {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid #555;
+  color: #888;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.mod-details-toggle:hover {
+  color: #ccc;
+  border-color: #888;
+}
+
+.mod-details {
+  margin-bottom: 8px;
+  max-height: 200px;
+  overflow-y: auto;
+  font-size: 11px;
+}
+
+/* Unlock notification */
+.unlock-message {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 12px 24px;
+  background: #1a3a1a;
+  border: 1px solid #4a4;
+  border-radius: 8px;
+  color: #7dff82;
+  font-size: 14px;
+  font-weight: 600;
+  z-index: 1000;
+  animation: fadeInOut 4s ease-in-out;
+}
+
+@keyframes fadeInOut {
+  0% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+  10% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  80% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  100% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+}

--- a/packages/viewer/src/App.css
+++ b/packages/viewer/src/App.css
@@ -347,29 +347,6 @@
   font-family: monospace;
 }
 
-.mod-details-toggle {
-  margin-left: auto;
-  background: transparent;
-  border: 1px solid #555;
-  color: #888;
-  padding: 2px 8px;
-  border-radius: 3px;
-  font-size: 11px;
-  cursor: pointer;
-}
-
-.mod-details-toggle:hover {
-  color: #ccc;
-  border-color: #888;
-}
-
-.mod-details {
-  margin-bottom: 8px;
-  max-height: 200px;
-  overflow-y: auto;
-  font-size: 11px;
-}
-
 /* Unlock notification */
 .unlock-message {
   position: fixed;

--- a/packages/viewer/src/components/CodeEditorPanel.tsx
+++ b/packages/viewer/src/components/CodeEditorPanel.tsx
@@ -9,28 +9,6 @@ type Props = {
   initialCode?: string;
 };
 
-/** Extract only VAR lines from fixedCode, hiding MOD blocks */
-function getDisplayFixedCode(fixedCode: string): string {
-  const lines = fixedCode.split("\n");
-  const result: string[] = [];
-  let inMod = false;
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed.startsWith("MOD START")) {
-      inMod = true;
-      continue;
-    }
-    if (trimmed === "MOD END") {
-      inMod = false;
-      continue;
-    }
-    if (!inMod && trimmed !== "") {
-      result.push(trimmed);
-    }
-  }
-  return result.join("\n");
-}
-
 export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode = "" }: Props) {
   const [code, setCode] = useState(puzzle?.editableCode ?? initialCode);
 
@@ -39,8 +17,9 @@ export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode
     onDirty?.();
   };
 
-  const fullCode = puzzle ? `${puzzle.fixedCode}\n${code}` : code;
-  const displayFixed = puzzle ? getDisplayFixedCode(puzzle.fixedCode) : "";
+  const fullCode = puzzle
+    ? `${puzzle.moduleDefs}${puzzle.fixedCode}\n${code}`
+    : code;
   const hasModules = puzzle?.availableModules && puzzle.availableModules.length > 0;
 
   return (
@@ -59,7 +38,7 @@ export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode
               </span>
             </div>
           )}
-          <pre className="fixed-code">{displayFixed}</pre>
+          <pre className="fixed-code">{puzzle.fixedCode}</pre>
         </>
       )}
       {!puzzle && (

--- a/packages/viewer/src/components/CodeEditorPanel.tsx
+++ b/packages/viewer/src/components/CodeEditorPanel.tsx
@@ -9,8 +9,31 @@ type Props = {
   initialCode?: string;
 };
 
+/** Extract only VAR lines from fixedCode, hiding MOD blocks */
+function getDisplayFixedCode(fixedCode: string): string {
+  const lines = fixedCode.split("\n");
+  const result: string[] = [];
+  let inMod = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("MOD START")) {
+      inMod = true;
+      continue;
+    }
+    if (trimmed === "MOD END") {
+      inMod = false;
+      continue;
+    }
+    if (!inMod && trimmed !== "") {
+      result.push(trimmed);
+    }
+  }
+  return result.join("\n");
+}
+
 export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode = "" }: Props) {
   const [code, setCode] = useState(puzzle?.editableCode ?? initialCode);
+  const [showModDetails, setShowModDetails] = useState(false);
 
   const handleChange = (value: string) => {
     setCode(value);
@@ -18,6 +41,8 @@ export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode
   };
 
   const fullCode = puzzle ? `${puzzle.fixedCode}\n${code}` : code;
+  const displayFixed = puzzle ? getDisplayFixedCode(puzzle.fixedCode) : "";
+  const hasModules = puzzle?.availableModules && puzzle.availableModules.length > 0;
 
   return (
     <div className="code-editor-panel">
@@ -27,7 +52,24 @@ export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode
             <h3>{puzzle.title}</h3>
           </div>
           <div className="puzzle-description">{puzzle.description}</div>
-          <pre className="fixed-code">{puzzle.fixedCode}</pre>
+          {hasModules && (
+            <div className="available-modules">
+              <span className="available-modules-label">利用可能モジュール: </span>
+              <span className="available-modules-list">
+                NAND, {puzzle.availableModules!.join(", ")}
+              </span>
+              <button
+                className="mod-details-toggle"
+                onClick={() => setShowModDetails(!showModDetails)}
+              >
+                {showModDetails ? "定義を隠す" : "定義を見る"}
+              </button>
+            </div>
+          )}
+          {showModDetails && (
+            <pre className="fixed-code mod-details">{puzzle.fixedCode}</pre>
+          )}
+          <pre className="fixed-code">{displayFixed}</pre>
         </>
       )}
       {!puzzle && (

--- a/packages/viewer/src/components/CodeEditorPanel.tsx
+++ b/packages/viewer/src/components/CodeEditorPanel.tsx
@@ -33,7 +33,6 @@ function getDisplayFixedCode(fixedCode: string): string {
 
 export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode = "" }: Props) {
   const [code, setCode] = useState(puzzle?.editableCode ?? initialCode);
-  const [showModDetails, setShowModDetails] = useState(false);
 
   const handleChange = (value: string) => {
     setCode(value);
@@ -56,18 +55,9 @@ export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode
             <div className="available-modules">
               <span className="available-modules-label">利用可能モジュール: </span>
               <span className="available-modules-list">
-                NAND, {puzzle.availableModules!.join(", ")}
+                {puzzle.availableModules!.join(", ")}
               </span>
-              <button
-                className="mod-details-toggle"
-                onClick={() => setShowModDetails(!showModDetails)}
-              >
-                {showModDetails ? "定義を隠す" : "定義を見る"}
-              </button>
             </div>
-          )}
-          {showModDetails && (
-            <pre className="fixed-code mod-details">{puzzle.fixedCode}</pre>
           )}
           <pre className="fixed-code">{displayFixed}</pre>
         </>

--- a/packages/viewer/src/lib/progress.ts
+++ b/packages/viewer/src/lib/progress.ts
@@ -1,0 +1,65 @@
+import type { Puzzle } from "./puzzles";
+
+const STORAGE_KEY = "nandlang-progress";
+
+export type ProgressData = {
+  completedLevels: number[];
+};
+
+function loadProgress(): ProgressData {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed.completedLevels)) {
+        return { completedLevels: parsed.completedLevels };
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return { completedLevels: [] };
+}
+
+function saveProgress(data: ProgressData): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export function getProgress(): ProgressData {
+  return loadProgress();
+}
+
+export function markLevelCompleted(puzzleId: number): ProgressData {
+  const progress = loadProgress();
+  if (!progress.completedLevels.includes(puzzleId)) {
+    progress.completedLevels.push(puzzleId);
+    saveProgress(progress);
+  }
+  return progress;
+}
+
+export function isLevelUnlocked(
+  puzzleId: number,
+  puzzles: Puzzle[],
+  progress: ProgressData,
+): boolean {
+  const index = puzzles.findIndex((p) => p.id === puzzleId);
+  if (index <= 0) return true; // First level is always unlocked
+  const prevPuzzle = puzzles[index - 1];
+  return progress.completedLevels.includes(prevPuzzle.id);
+}
+
+export function getUnlockedModules(
+  puzzles: Puzzle[],
+  progress: ProgressData,
+): string[] {
+  return puzzles
+    .filter(
+      (p) => p.unlocksModule && progress.completedLevels.includes(p.id),
+    )
+    .map((p) => p.unlocksModule!);
+}
+
+export function resetProgress(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -20,6 +20,9 @@ export type Puzzle = {
   inputNames: string[];
   outputNames: string[];
   testCases: PuzzleTestCase[];
+  /** MOD定義（コンパイル時にfixedCodeの前に結合される、表示しない） */
+  moduleDefs: string;
+  /** 表示されるfixed部分（BITIN/BITOUT宣言等） */
   fixedCode: string;
   editableCode: string;
   unlocksModule?: string;
@@ -48,6 +51,7 @@ export const puzzles: Puzzle[] = [
       tc({ a: false }, { out: false }),
       tc({ a: true }, { out: true }),
     ],
+    moduleDefs: "",
     fixedCode: `VAR a BITIN\nVAR out BITOUT`,
     editableCode: `WIRE a _ TO out _
 `,
@@ -65,6 +69,7 @@ export const puzzles: Puzzle[] = [
       tc({ a: true, b: false }, { out: true }),
       tc({ a: true, b: true }, { out: false }),
     ],
+    moduleDefs: "",
     fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
     editableCode: `VAR nand NAND
 WIRE a _ TO nand i0
@@ -84,6 +89,7 @@ WIRE nand _ TO out _
       tc({ a: false }, { out: true }),
       tc({ a: true }, { out: false }),
     ],
+    moduleDefs: "",
     fixedCode: `VAR a BITIN\nVAR out BITOUT`,
     editableCode: `VAR nand NAND
 WIRE a _ TO nand i0
@@ -106,7 +112,8 @@ WIRE nand _ TO out _
       tc({ a: true, b: false }, { out: false }),
       tc({ a: true, b: true }, { out: true }),
     ],
-    fixedCode: `${NOT}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    moduleDefs: NOT,
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
     editableCode: `VAR nand NAND
 VAR not NOT
 WIRE a _ TO nand i0
@@ -130,7 +137,8 @@ WIRE not _ TO out _
       tc({ a: true, b: false }, { out: true }),
       tc({ a: true, b: true }, { out: true }),
     ],
-    fixedCode: `${NOT}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    moduleDefs: NOT,
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
     editableCode: `VAR na NOT
 VAR nb NOT
 VAR nand NAND
@@ -156,7 +164,8 @@ WIRE nand _ TO out _
       tc({ a: true, b: false }, { out: false }),
       tc({ a: true, b: true }, { out: false }),
     ],
-    fixedCode: `${NOT}${AND}${OR}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    moduleDefs: `${NOT}${AND}${OR}`,
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
     editableCode: `VAR or OR
 VAR not NOT
 WIRE a _ TO or i0
@@ -180,7 +189,8 @@ WIRE not _ TO out _
       tc({ a: true, b: false }, { out: true }),
       tc({ a: true, b: true }, { out: false }),
     ],
-    fixedCode: `${NOT}${AND}${OR}${NOR}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    moduleDefs: `${NOT}${AND}${OR}${NOR}`,
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
     editableCode: `VAR nand NAND
 VAR or OR
 VAR and AND
@@ -208,7 +218,8 @@ WIRE and _ TO out _
       tc({ a: true, b: false }, { out: false }),
       tc({ a: true, b: true }, { out: true }),
     ],
-    fixedCode: `${NOT}${AND}${OR}${NOR}${XOR}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}`,
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
     editableCode: `VAR xor XOR
 VAR not NOT
 WIRE a _ TO xor i0
@@ -236,7 +247,8 @@ WIRE not _ TO out _
       tc({ a: true, b: true, c: false }, { out: false }),
       tc({ a: true, b: true, c: true }, { out: true }),
     ],
-    fixedCode: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}VAR a BITIN\nVAR b BITIN\nVAR c BITIN\nVAR out BITOUT`,
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}`,
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR c BITIN\nVAR out BITOUT`,
     editableCode: `VAR a0 AND
 VAR a1 AND
 WIRE a _ TO a0 i0
@@ -265,7 +277,8 @@ WIRE a1 _ TO out _
       tc({ a: true, b: true, c: false }, { out: true }),
       tc({ a: true, b: true, c: true }, { out: true }),
     ],
-    fixedCode: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}VAR a BITIN\nVAR b BITIN\nVAR c BITIN\nVAR out BITOUT`,
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}`,
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR c BITIN\nVAR out BITOUT`,
     editableCode: `VAR o0 OR
 VAR o1 OR
 WIRE a _ TO o0 i0

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -49,7 +49,8 @@ export const puzzles: Puzzle[] = [
       tc({ a: true }, { out: true }),
     ],
     fixedCode: `VAR a BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `WIRE a _ TO out _
+`,
   },
   {
     id: 2,
@@ -65,7 +66,12 @@ export const puzzles: Puzzle[] = [
       tc({ a: true, b: true }, { out: false }),
     ],
     fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `VAR nand NAND
+WIRE a _ TO nand i0
+WIRE b _ TO nand i1
+WIRE nand _ TO out _
+`,
+    availableModules: ["NAND"],
   },
   {
     id: 3,
@@ -79,8 +85,13 @@ export const puzzles: Puzzle[] = [
       tc({ a: true }, { out: false }),
     ],
     fixedCode: `VAR a BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `VAR nand NAND
+WIRE a _ TO nand i0
+WIRE a _ TO nand i1
+WIRE nand _ TO out _
+`,
     unlocksModule: "NOT",
+    availableModules: ["NAND"],
   },
   {
     id: 4,
@@ -96,9 +107,15 @@ export const puzzles: Puzzle[] = [
       tc({ a: true, b: true }, { out: true }),
     ],
     fixedCode: `${NOT}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `VAR nand NAND
+VAR not NOT
+WIRE a _ TO nand i0
+WIRE b _ TO nand i1
+WIRE nand _ TO not _
+WIRE not _ TO out _
+`,
     unlocksModule: "AND",
-    availableModules: ["NOT"],
+    availableModules: ["NAND", "NOT"],
   },
   {
     id: 5,
@@ -114,9 +131,17 @@ export const puzzles: Puzzle[] = [
       tc({ a: true, b: true }, { out: true }),
     ],
     fixedCode: `${NOT}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `VAR na NOT
+VAR nb NOT
+VAR nand NAND
+WIRE a _ TO na _
+WIRE b _ TO nb _
+WIRE na _ TO nand i0
+WIRE nb _ TO nand i1
+WIRE nand _ TO out _
+`,
     unlocksModule: "OR",
-    availableModules: ["NOT"],
+    availableModules: ["NAND", "NOT"],
   },
   {
     id: 6,
@@ -132,9 +157,15 @@ export const puzzles: Puzzle[] = [
       tc({ a: true, b: true }, { out: false }),
     ],
     fixedCode: `${NOT}${AND}${OR}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `VAR or OR
+VAR not NOT
+WIRE a _ TO or i0
+WIRE b _ TO or i1
+WIRE or _ TO not _
+WIRE not _ TO out _
+`,
     unlocksModule: "NOR",
-    availableModules: ["NOT", "AND", "OR"],
+    availableModules: ["NAND", "NOT", "AND", "OR"],
   },
   {
     id: 7,
@@ -150,9 +181,19 @@ export const puzzles: Puzzle[] = [
       tc({ a: true, b: true }, { out: false }),
     ],
     fixedCode: `${NOT}${AND}${OR}${NOR}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `VAR nand NAND
+VAR or OR
+VAR and AND
+WIRE a _ TO nand i0
+WIRE b _ TO nand i1
+WIRE a _ TO or i0
+WIRE b _ TO or i1
+WIRE nand _ TO and i0
+WIRE or _ TO and i1
+WIRE and _ TO out _
+`,
     unlocksModule: "XOR",
-    availableModules: ["NOT", "AND", "OR", "NOR"],
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR"],
   },
   {
     id: 8,
@@ -168,9 +209,15 @@ export const puzzles: Puzzle[] = [
       tc({ a: true, b: true }, { out: true }),
     ],
     fixedCode: `${NOT}${AND}${OR}${NOR}${XOR}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `VAR xor XOR
+VAR not NOT
+WIRE a _ TO xor i0
+WIRE b _ TO xor i1
+WIRE xor _ TO not _
+WIRE not _ TO out _
+`,
     unlocksModule: "XNOR",
-    availableModules: ["NOT", "AND", "OR", "NOR", "XOR"],
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR"],
   },
   {
     id: 9,
@@ -190,9 +237,16 @@ export const puzzles: Puzzle[] = [
       tc({ a: true, b: true, c: true }, { out: true }),
     ],
     fixedCode: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}VAR a BITIN\nVAR b BITIN\nVAR c BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `VAR a0 AND
+VAR a1 AND
+WIRE a _ TO a0 i0
+WIRE b _ TO a0 i1
+WIRE a0 _ TO a1 i0
+WIRE c _ TO a1 i1
+WIRE a1 _ TO out _
+`,
     unlocksModule: "AND3",
-    availableModules: ["NOT", "AND", "OR", "NOR", "XOR", "XNOR"],
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR"],
   },
   {
     id: 10,
@@ -212,8 +266,15 @@ export const puzzles: Puzzle[] = [
       tc({ a: true, b: true, c: true }, { out: true }),
     ],
     fixedCode: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}VAR a BITIN\nVAR b BITIN\nVAR c BITIN\nVAR out BITOUT`,
-    editableCode: "",
+    editableCode: `VAR o0 OR
+VAR o1 OR
+WIRE a _ TO o0 i0
+WIRE b _ TO o0 i1
+WIRE o0 _ TO o1 i0
+WIRE c _ TO o1 i1
+WIRE o1 _ TO out _
+`,
     unlocksModule: "OR3",
-    availableModules: ["NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3"],
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3"],
   },
 ];

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -1,3 +1,13 @@
+import {
+  NOT,
+  AND,
+  OR,
+  NOR,
+  XOR,
+  XNOR,
+  AND3,
+} from "@nandlang-ts/language/code-fragments";
+
 export type PuzzleTestCase = {
   inputs: Map<string, boolean>;
   expectedOutputs: Map<string, boolean>;
@@ -12,6 +22,8 @@ export type Puzzle = {
   testCases: PuzzleTestCase[];
   fixedCode: string;
   editableCode: string;
+  unlocksModule?: string;
+  availableModules?: string[];
 };
 
 function tc(
@@ -27,28 +39,54 @@ function tc(
 export const puzzles: Puzzle[] = [
   {
     id: 1,
-    title: "Lv1: NOT",
+    title: "Lv1: Wire",
     description:
-      "NANDゲートを使ってNOTゲートを作ってください。\n入力aの反転をoutに出力します。",
+      "入力aをそのまま出力outに接続してください。\nWIRE文で変数同士を結線します。",
+    inputNames: ["a"],
+    outputNames: ["out"],
+    testCases: [
+      tc({ a: false }, { out: false }),
+      tc({ a: true }, { out: true }),
+    ],
+    fixedCode: `VAR a BITIN\nVAR out BITOUT`,
+    editableCode: "",
+  },
+  {
+    id: 2,
+    title: "Lv2: NAND",
+    description:
+      "2つの入力をNANDゲートに接続し、結果をoutに出力してください。\nVAR文で変数を宣言し、WIRE文で結線します。",
+    inputNames: ["a", "b"],
+    outputNames: ["out"],
+    testCases: [
+      tc({ a: false, b: false }, { out: true }),
+      tc({ a: false, b: true }, { out: true }),
+      tc({ a: true, b: false }, { out: true }),
+      tc({ a: true, b: true }, { out: false }),
+    ],
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    editableCode: "",
+  },
+  {
+    id: 3,
+    title: "Lv3: NOT",
+    description:
+      "NANDゲートを使って入力aの反転をoutに出力してください。",
     inputNames: ["a"],
     outputNames: ["out"],
     testCases: [
       tc({ a: false }, { out: true }),
       tc({ a: true }, { out: false }),
     ],
-    fixedCode: `VAR a BITIN
-VAR out BITOUT
-VAR nand NAND`,
-    editableCode: `WIRE a _ TO nand i0
-WIRE a _ TO nand i1
-WIRE nand _ TO out _
-`,
+    fixedCode: `VAR a BITIN\nVAR out BITOUT`,
+    editableCode: "",
+    unlocksModule: "NOT",
   },
   {
-    id: 2,
-    title: "Lv2: AND",
+    id: 4,
+    title: "Lv4: AND",
     description:
-      "NANDゲートを使ってANDゲートを作ってください。\naとbの両方が1のときだけoutが1になります。",
+      "aとbの両方が1のときだけoutが1になる回路を作ってください。",
     inputNames: ["a", "b"],
     outputNames: ["out"],
     testCases: [
@@ -57,23 +95,16 @@ WIRE nand _ TO out _
       tc({ a: true, b: false }, { out: false }),
       tc({ a: true, b: true }, { out: true }),
     ],
-    fixedCode: `VAR a BITIN
-VAR b BITIN
-VAR out BITOUT
-VAR nand NAND
-VAR n2 NAND`,
-    editableCode: `WIRE a _ TO nand i0
-WIRE b _ TO nand i1
-WIRE nand _ TO n2 i0
-WIRE nand _ TO n2 i1
-WIRE n2 _ TO out _
-`,
+    fixedCode: `${NOT}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    editableCode: "",
+    unlocksModule: "AND",
+    availableModules: ["NOT"],
   },
   {
-    id: 3,
-    title: "Lv3: OR",
+    id: 5,
+    title: "Lv5: OR",
     description:
-      "NANDゲートを使ってORゲートを作ってください。\naまたはbのどちらかが1ならoutが1になります。",
+      "aまたはbのどちらかが1ならoutが1になる回路を作ってください。",
     inputNames: ["a", "b"],
     outputNames: ["out"],
     testCases: [
@@ -82,26 +113,16 @@ WIRE n2 _ TO out _
       tc({ a: true, b: false }, { out: true }),
       tc({ a: true, b: true }, { out: true }),
     ],
-    fixedCode: `VAR a BITIN
-VAR b BITIN
-VAR out BITOUT
-VAR na NAND
-VAR nb NAND
-VAR nand NAND`,
-    editableCode: `WIRE a _ TO na i0
-WIRE a _ TO na i1
-WIRE b _ TO nb i0
-WIRE b _ TO nb i1
-WIRE na _ TO nand i0
-WIRE nb _ TO nand i1
-WIRE nand _ TO out _
-`,
+    fixedCode: `${NOT}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    editableCode: "",
+    unlocksModule: "OR",
+    availableModules: ["NOT"],
   },
   {
-    id: 4,
-    title: "Lv4: NOR",
+    id: 6,
+    title: "Lv6: NOR",
     description:
-      "NANDゲートを使ってNORゲートを作ってください。\naとbの両方が0のときだけoutが1になります。",
+      "aとbの両方が0のときだけoutが1になる回路を作ってください。",
     inputNames: ["a", "b"],
     outputNames: ["out"],
     testCases: [
@@ -110,29 +131,16 @@ WIRE nand _ TO out _
       tc({ a: true, b: false }, { out: false }),
       tc({ a: true, b: true }, { out: false }),
     ],
-    fixedCode: `VAR a BITIN
-VAR b BITIN
-VAR out BITOUT
-VAR na NAND
-VAR nb NAND
-VAR or NAND
-VAR not NAND`,
-    editableCode: `WIRE a _ TO na i0
-WIRE a _ TO na i1
-WIRE b _ TO nb i0
-WIRE b _ TO nb i1
-WIRE na _ TO or i0
-WIRE nb _ TO or i1
-WIRE or _ TO not i0
-WIRE or _ TO not i1
-WIRE not _ TO out _
-`,
+    fixedCode: `${NOT}${AND}${OR}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    editableCode: "",
+    unlocksModule: "NOR",
+    availableModules: ["NOT", "AND", "OR"],
   },
   {
-    id: 5,
-    title: "Lv5: XOR",
+    id: 7,
+    title: "Lv7: XOR",
     description:
-      "NANDゲートを使ってXORゲートを作ってください。\naとbが異なるときだけoutが1になります。",
+      "aとbが異なるときだけoutが1になる回路を作ってください。",
     inputNames: ["a", "b"],
     outputNames: ["out"],
     testCases: [
@@ -141,52 +149,71 @@ WIRE not _ TO out _
       tc({ a: true, b: false }, { out: true }),
       tc({ a: true, b: true }, { out: false }),
     ],
-    fixedCode: `VAR a BITIN
-VAR b BITIN
-VAR out BITOUT
-VAR nand NAND
-VAR n1 NAND
-VAR n2 NAND
-VAR n3 NAND`,
-    editableCode: `WIRE a _ TO nand i0
-WIRE b _ TO nand i1
-WIRE a _ TO n1 i0
-WIRE nand _ TO n1 i1
-WIRE nand _ TO n2 i0
-WIRE b _ TO n2 i1
-WIRE n1 _ TO n3 i0
-WIRE n2 _ TO n3 i1
-WIRE n3 _ TO out _
-`,
+    fixedCode: `${NOT}${AND}${OR}${NOR}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    editableCode: "",
+    unlocksModule: "XOR",
+    availableModules: ["NOT", "AND", "OR", "NOR"],
   },
   {
-    id: 6,
-    title: "Lv6: SR Latch",
+    id: 8,
+    title: "Lv8: XNOR",
     description:
-      "FLIPFLOPを使ってSRラッチを作ってください。\nsが1のときqを1にセット、rが1のときqを0にリセットします。\nどちらも0のときは前の状態を保持します。\n(テストは順番に実行され、状態が引き継がれます)",
-    inputNames: ["s", "r"],
-    outputNames: ["q"],
+      "aとbが同じときだけoutが1になる回路を作ってください。",
+    inputNames: ["a", "b"],
+    outputNames: ["out"],
     testCases: [
-      // Initial state: q=0
-      tc({ s: false, r: false }, { q: false }),
-      // Set: q becomes 1
-      tc({ s: true, r: false }, { q: true }),
-      // Hold: q stays 1
-      tc({ s: false, r: false }, { q: true }),
-      // Reset: q becomes 0
-      tc({ s: false, r: true }, { q: false }),
-      // Hold: q stays 0
-      tc({ s: false, r: false }, { q: false }),
-      // Set again: q becomes 1
-      tc({ s: true, r: false }, { q: true }),
+      tc({ a: false, b: false }, { out: true }),
+      tc({ a: false, b: true }, { out: false }),
+      tc({ a: true, b: false }, { out: false }),
+      tc({ a: true, b: true }, { out: true }),
     ],
-    fixedCode: `VAR s BITIN
-VAR r BITIN
-VAR q BITOUT
-VAR ff FLIPFLOP`,
-    editableCode: `WIRE s _ TO ff s
-WIRE r _ TO ff r
-WIRE ff _ TO q _
-`,
+    fixedCode: `${NOT}${AND}${OR}${NOR}${XOR}VAR a BITIN\nVAR b BITIN\nVAR out BITOUT`,
+    editableCode: "",
+    unlocksModule: "XNOR",
+    availableModules: ["NOT", "AND", "OR", "NOR", "XOR"],
+  },
+  {
+    id: 9,
+    title: "Lv9: AND3",
+    description:
+      "3つの入力a,b,cすべてが1のときだけoutが1になる回路を作ってください。",
+    inputNames: ["a", "b", "c"],
+    outputNames: ["out"],
+    testCases: [
+      tc({ a: false, b: false, c: false }, { out: false }),
+      tc({ a: false, b: false, c: true }, { out: false }),
+      tc({ a: false, b: true, c: false }, { out: false }),
+      tc({ a: false, b: true, c: true }, { out: false }),
+      tc({ a: true, b: false, c: false }, { out: false }),
+      tc({ a: true, b: false, c: true }, { out: false }),
+      tc({ a: true, b: true, c: false }, { out: false }),
+      tc({ a: true, b: true, c: true }, { out: true }),
+    ],
+    fixedCode: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}VAR a BITIN\nVAR b BITIN\nVAR c BITIN\nVAR out BITOUT`,
+    editableCode: "",
+    unlocksModule: "AND3",
+    availableModules: ["NOT", "AND", "OR", "NOR", "XOR", "XNOR"],
+  },
+  {
+    id: 10,
+    title: "Lv10: OR3",
+    description:
+      "3つの入力a,b,cのいずれかが1ならoutが1になる回路を作ってください。",
+    inputNames: ["a", "b", "c"],
+    outputNames: ["out"],
+    testCases: [
+      tc({ a: false, b: false, c: false }, { out: false }),
+      tc({ a: false, b: false, c: true }, { out: true }),
+      tc({ a: false, b: true, c: false }, { out: true }),
+      tc({ a: false, b: true, c: true }, { out: true }),
+      tc({ a: true, b: false, c: false }, { out: true }),
+      tc({ a: true, b: false, c: true }, { out: true }),
+      tc({ a: true, b: true, c: false }, { out: true }),
+      tc({ a: true, b: true, c: true }, { out: true }),
+    ],
+    fixedCode: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}VAR a BITIN\nVAR b BITIN\nVAR c BITIN\nVAR out BITOUT`,
+    editableCode: "",
+    unlocksModule: "OR3",
+    availableModules: ["NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3"],
   },
 ];

--- a/packages/viewer/src/pages/LevelPage.tsx
+++ b/packages/viewer/src/pages/LevelPage.tsx
@@ -88,7 +88,7 @@ export function LevelPage() {
   useEffect(() => {
     if (!currentPuzzle) return;
     tc.loadTestCases(currentPuzzle.testCases);
-    handleCompile(`${currentPuzzle.fixedCode}\n${currentPuzzle.editableCode}`);
+    handleCompile(`${currentPuzzle.moduleDefs}${currentPuzzle.fixedCode}\n${currentPuzzle.editableCode}`);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/viewer/src/pages/LevelPage.tsx
+++ b/packages/viewer/src/pages/LevelPage.tsx
@@ -8,6 +8,11 @@ import { TestCasePanel } from "../components/TestCasePanel";
 import { useCircuit } from "../hooks/useCircuit";
 import { useTestCases } from "../hooks/useTestCases";
 import { puzzles } from "../lib/puzzles";
+import {
+  getProgress,
+  isLevelUnlocked,
+  markLevelCompleted,
+} from "../lib/progress";
 
 export function LevelPage() {
   const { id } = useParams<{ id: string }>();
@@ -22,8 +27,15 @@ export function LevelPage() {
   const [compiledCode, setCompiledCode] = useState<string | null>(null);
   const [fitViewTrigger, setFitViewTrigger] = useState(0);
   const [dirty, setDirty] = useState(false);
+  const [unlockMessage, setUnlockMessage] = useState<string | null>(null);
 
   const tc = useTestCases(compiledCode, circuit.updateNodeSignals);
+
+  // Check if level is locked
+  const progress = useMemo(() => getProgress(), []);
+  const isUnlocked = currentPuzzle
+    ? isLevelUnlocked(currentPuzzle.id, puzzles, progress)
+    : false;
 
   const handleCompile = useCallback(
     (code: string) => {
@@ -42,6 +54,21 @@ export function LevelPage() {
       navigate(`/level/${nextPuzzle.id}`);
     }
   }, [levelIndex, navigate]);
+
+  // Mark level completed when all tests pass
+  useEffect(() => {
+    if (tc.allPassed && currentPuzzle) {
+      markLevelCompleted(currentPuzzle.id);
+      if (currentPuzzle.unlocksModule) {
+        setUnlockMessage(
+          `${currentPuzzle.unlocksModule} モジュールが解放されました！`,
+        );
+      }
+      // Clear unlock message after a delay
+      const timer = setTimeout(() => setUnlockMessage(null), 4000);
+      return () => clearTimeout(timer);
+    }
+  }, [tc.allPassed, currentPuzzle]);
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) => {
@@ -65,7 +92,8 @@ export function LevelPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (!currentPuzzle) {
+  // Redirect locked levels
+  if (!currentPuzzle || !isUnlocked) {
     return <Navigate to="/levels" replace />;
   }
 
@@ -95,6 +123,9 @@ export function LevelPage() {
         isLastLevel={levelIndex >= puzzles.length - 1}
         disabled={dirty}
       />
+      {unlockMessage && (
+        <div className="unlock-message">{unlockMessage}</div>
+      )}
     </div>
   );
 }

--- a/packages/viewer/src/pages/LevelSelectPage.css
+++ b/packages/viewer/src/pages/LevelSelectPage.css
@@ -15,6 +15,7 @@
   margin: 0;
   font-size: 28px;
   color: #eee;
+  flex: 1;
 }
 
 .back-link {
@@ -25,6 +26,21 @@
 
 .back-link:hover {
   color: #ccc;
+}
+
+.reset-progress-btn {
+  background: transparent;
+  border: 1px solid #666;
+  color: #999;
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.reset-progress-btn:hover {
+  border-color: #e55;
+  color: #e55;
 }
 
 .level-grid {
@@ -48,6 +64,25 @@
 .level-card:hover {
   border-color: #4a9eff;
   background: #333;
+}
+
+.level-card-locked {
+  opacity: 0.4;
+  pointer-events: none;
+  cursor: default;
+}
+
+.level-card-locked:hover {
+  border-color: #444;
+  background: #2a2a2a;
+}
+
+.level-card-completed {
+  border-color: #4a4;
+}
+
+.level-card-check {
+  color: #4a4;
 }
 
 .level-card-title {

--- a/packages/viewer/src/pages/LevelSelectPage.tsx
+++ b/packages/viewer/src/pages/LevelSelectPage.tsx
@@ -1,8 +1,21 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { puzzles } from "../lib/puzzles";
+import {
+  getProgress,
+  isLevelUnlocked,
+  resetProgress,
+} from "../lib/progress";
 import "./LevelSelectPage.css";
 
 export function LevelSelectPage() {
+  const [progress, setProgress] = useState(getProgress);
+
+  const handleReset = () => {
+    resetProgress();
+    setProgress({ completedLevels: [] });
+  };
+
   return (
     <div className="level-select-page">
       <div className="level-select-header">
@@ -10,18 +23,38 @@ export function LevelSelectPage() {
           &larr; Back
         </Link>
         <h1>Puzzles</h1>
+        <button className="reset-progress-btn" onClick={handleReset}>
+          進捗リセット
+        </button>
       </div>
       <div className="level-grid">
-        {puzzles.map((puzzle) => (
-          <Link
-            key={puzzle.id}
-            to={`/level/${puzzle.id}`}
-            className="level-card"
-          >
-            <span className="level-card-title">{puzzle.title}</span>
-            <span className="level-card-desc">{puzzle.description}</span>
-          </Link>
-        ))}
+        {puzzles.map((puzzle) => {
+          const unlocked = isLevelUnlocked(puzzle.id, puzzles, progress);
+          const completed = progress.completedLevels.includes(puzzle.id);
+
+          if (!unlocked) {
+            return (
+              <div key={puzzle.id} className="level-card level-card-locked">
+                <span className="level-card-title">{puzzle.title}</span>
+                <span className="level-card-desc">🔒</span>
+              </div>
+            );
+          }
+
+          return (
+            <Link
+              key={puzzle.id}
+              to={`/level/${puzzle.id}`}
+              className={`level-card ${completed ? "level-card-completed" : ""}`}
+            >
+              <span className="level-card-title">
+                {completed && <span className="level-card-check">✓ </span>}
+                {puzzle.title}
+              </span>
+              <span className="level-card-desc">{puzzle.description}</span>
+            </Link>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- 6レベル（NOT〜SR Latch）を10レベル（Wire〜OR3）に再設計。段階的に学べる構成に変更
- モジュール解放システム追加: レベルクリア時にゲートがモジュールとして後続レベルで使用可能に
- 進捗管理（localStorage）: レベルロック/アンロック、クリア済みチェックマーク、進捗リセット機能
- fixedCodeとmoduleDefsを分離し、MOD定義は非表示でコンパイル時のみ結合

## Test plan
- [ ] Lv1から順にプレイして各レベルの真理値表テストが通ることを確認
- [ ] レベルクリア後にモジュール解放通知が表示されることを確認
- [ ] 次レベルがアンロックされることを確認
- [ ] ロック済みレベルにアクセスできないことを確認
- [ ] ブラウザリロード後も進捗が保持されることを確認
- [ ] 進捗リセットボタンが動作することを確認
- [ ] `npm test -w packages/language` がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)