### PR TITLE
Add ON puzzle level (Lv6) after OR

### DIFF
--- a/packages/language/src/code-fragments.test.ts
+++ b/packages/language/src/code-fragments.test.ts
@@ -5,6 +5,7 @@ import {
   DECODER_3BIT,
   NOR,
   NOT,
+  ON,
   OR,
   OR3,
   XNOR,
@@ -19,6 +20,17 @@ const getRunner = (program: string) => {
     return [...vm.run(new Map(inputs)).entries()];
   };
 };
+
+test("ON", () => {
+  const runner = getRunner(`
+    ${ON}
+    VAR out BITOUT
+
+    VAR on ON
+    WIRE on _ TO out _
+  `);
+  expect(runner([])).toEqual([["out", true]]);
+});
 
 test("NOT", () => {
   const runner = getRunner(`

--- a/packages/language/src/code-fragments.ts
+++ b/packages/language/src/code-fragments.ts
@@ -1,3 +1,11 @@
+export const ON = `\
+MOD START ON
+  VAR nand NAND
+  VAR out BITOUT
+  WIRE nand _ TO out _
+MOD END
+`;
+
 export const NOT = `\
 MOD START NOT
   VAR in BITIN

--- a/packages/viewer/src/components/HelpManual.tsx
+++ b/packages/viewer/src/components/HelpManual.tsx
@@ -142,6 +142,36 @@ VAR x NOT`}</pre>
     ),
   },
   {
+    id: "gate-on",
+    title: "ON: 常時1出力",
+    content: (
+      <>
+        <p>入力なしで常に1を出力します。</p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>out</code> / <code>_</code></td><td>出力</td></tr>
+          </tbody>
+        </table>
+        <p>真理値表:</p>
+        <table>
+          <thead>
+            <tr><th>出力</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td></tr>
+          </tbody>
+        </table>
+        <details>
+          <summary>ヒント: NANDから常時1を作るには</summary>
+          <p>NANDゲートの入力に何も接続しないと、デフォルト値(0)が使われます。NAND(0, 0) = 1 です。</p>
+        </details>
+      </>
+    ),
+  },
+  {
     id: "gate-not",
     title: "NOT: 反転",
     content: (

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -156,7 +156,21 @@ WIRE nand _ TO out _
   },
   {
     id: 6,
-    title: "Lv6: NOR",
+    title: "Lv6: ON",
+    description:
+      "入力なしで常に1を出力する回路を作ってください。\nNANDゲートの入力に何も接続しないとどうなるか考えてみましょう。",
+    inputNames: [],
+    outputNames: ["out"],
+    testCases: [tc({}, { out: true })],
+    moduleDefs: "",
+    fixedCode: `VAR out BITOUT`,
+    editableCode: `VAR nand NAND\nWIRE nand _ TO out _\n`,
+    availableModules: ["NAND"],
+    helpSections: ["mod-nand", "gate-on"],
+  },
+  {
+    id: 7,
+    title: "Lv7: NOR",
     description:
       "aとbの両方が0のときだけoutが1になる回路を作ってください。",
     inputNames: ["a", "b"],
@@ -180,8 +194,8 @@ WIRE not _ TO out _
     helpSections: ["gate-nor"],
   },
   {
-    id: 7,
-    title: "Lv7: XOR",
+    id: 8,
+    title: "Lv8: XOR",
     description:
       "aとbが異なるときだけoutが1になる回路を作ってください。",
     inputNames: ["a", "b"],
@@ -209,8 +223,8 @@ WIRE and _ TO out _
     helpSections: ["gate-xor"],
   },
   {
-    id: 8,
-    title: "Lv8: XNOR",
+    id: 9,
+    title: "Lv9: XNOR",
     description:
       "aとbが同じときだけoutが1になる回路を作ってください。",
     inputNames: ["a", "b"],
@@ -234,8 +248,8 @@ WIRE not _ TO out _
     helpSections: ["gate-xnor"],
   },
   {
-    id: 9,
-    title: "Lv9: AND3",
+    id: 10,
+    title: "Lv10: AND3",
     description:
       "3つの入力a,b,cすべてが1のときだけoutが1になる回路を作ってください。",
     inputNames: ["a", "b", "c"],
@@ -264,8 +278,8 @@ WIRE a1 _ TO out _
     helpSections: ["gate-and"],
   },
   {
-    id: 10,
-    title: "Lv10: OR3",
+    id: 11,
+    title: "Lv11: OR3",
     description:
       "3つの入力a,b,cのいずれかが1ならoutが1になる回路を作ってください。",
     inputNames: ["a", "b", "c"],


### PR DESCRIPTION
## Summary
- ORレベル(Lv5)の後にONモジュールのパズルレベル(Lv6)を追加
- NANDゲートの入力未接続時のデフォルト値(0)を利用し、NAND(0,0)=1で常に1を出力する回路を作るパズル
- ONモジュールのcode-fragment定義、テスト、ヘルプマニュアルセクションを追加
- 後続レベル(NOR〜OR3)のid/titleをLv7〜Lv11に更新

## Test plan
- [x] language パッケージのユニットテスト通過（ONモジュールテスト含む）
- [x] viewer パッケージのビルド成功
- [ ] Lv6: ON パズルが正しく表示・動作することを確認
- [ ] 後続レベルのナビゲーションが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)