### PR TITLE
Add Lv12-16: Adder, Decoder, Encoder, Byte Add with BYTEIN/BYTEOUT

### DIFF
--- a/packages/language/src/code-fragments.test.ts
+++ b/packages/language/src/code-fragments.test.ts
@@ -1,8 +1,12 @@
 import { expect, test } from "vitest";
 import {
+  ADD,
   AND,
   AND3,
+  BYTEADD,
+  DEC,
   DECODER_3BIT,
+  ENC,
   NOR,
   NOT,
   ON,
@@ -376,6 +380,480 @@ test("XNOR", () => {
       ["y", true],
     ]),
   ).toEqual([["out", true]]);
+});
+
+test("ADD", () => {
+  const runner = getRunner(`
+    ${ADD}
+    VAR a BITIN
+    VAR b BITIN
+    VAR cin BITIN
+    VAR s BITOUT
+    VAR cout BITOUT
+
+    VAR add ADD
+    WIRE a _ TO add i0
+    WIRE b _ TO add i1
+    WIRE cin _ TO add i2
+    WIRE add o0 TO s _
+    WIRE add o1 TO cout _
+  `);
+  expect(
+    runner([
+      ["a", false],
+      ["b", false],
+      ["cin", false],
+    ]),
+  ).toEqual([
+    ["s", false],
+    ["cout", false],
+  ]);
+  expect(
+    runner([
+      ["a", false],
+      ["b", false],
+      ["cin", true],
+    ]),
+  ).toEqual([
+    ["s", true],
+    ["cout", false],
+  ]);
+  expect(
+    runner([
+      ["a", false],
+      ["b", true],
+      ["cin", false],
+    ]),
+  ).toEqual([
+    ["s", true],
+    ["cout", false],
+  ]);
+  expect(
+    runner([
+      ["a", false],
+      ["b", true],
+      ["cin", true],
+    ]),
+  ).toEqual([
+    ["s", false],
+    ["cout", true],
+  ]);
+  expect(
+    runner([
+      ["a", true],
+      ["b", false],
+      ["cin", false],
+    ]),
+  ).toEqual([
+    ["s", true],
+    ["cout", false],
+  ]);
+  expect(
+    runner([
+      ["a", true],
+      ["b", false],
+      ["cin", true],
+    ]),
+  ).toEqual([
+    ["s", false],
+    ["cout", true],
+  ]);
+  expect(
+    runner([
+      ["a", true],
+      ["b", true],
+      ["cin", false],
+    ]),
+  ).toEqual([
+    ["s", false],
+    ["cout", true],
+  ]);
+  expect(
+    runner([
+      ["a", true],
+      ["b", true],
+      ["cin", true],
+    ]),
+  ).toEqual([
+    ["s", true],
+    ["cout", true],
+  ]);
+});
+
+test("DEC", () => {
+  const runner = getRunner(`
+    ${DEC}
+    VAR x BITIN
+    VAR y BITIN
+    VAR z BITIN
+    VAR o0 BITOUT
+    VAR o1 BITOUT
+    VAR o2 BITOUT
+    VAR o3 BITOUT
+    VAR o4 BITOUT
+    VAR o5 BITOUT
+    VAR o6 BITOUT
+    VAR o7 BITOUT
+    VAR dec DEC
+    WIRE x _ TO dec i0
+    WIRE y _ TO dec i1
+    WIRE z _ TO dec i2
+    WIRE dec o0 TO o0 _
+    WIRE dec o1 TO o1 _
+    WIRE dec o2 TO o2 _
+    WIRE dec o3 TO o3 _
+    WIRE dec o4 TO o4 _
+    WIRE dec o5 TO o5 _
+    WIRE dec o6 TO o6 _
+    WIRE dec o7 TO o7 _
+  `);
+  expect(
+    runner([
+      ["x", false],
+      ["y", false],
+      ["z", false],
+    ]),
+  ).toEqual([
+    ["o0", true],
+    ["o1", false],
+    ["o2", false],
+    ["o3", false],
+    ["o4", false],
+    ["o5", false],
+    ["o6", false],
+    ["o7", false],
+  ]);
+  expect(
+    runner([
+      ["x", true],
+      ["y", false],
+      ["z", false],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", true],
+    ["o2", false],
+    ["o3", false],
+    ["o4", false],
+    ["o5", false],
+    ["o6", false],
+    ["o7", false],
+  ]);
+  expect(
+    runner([
+      ["x", false],
+      ["y", true],
+      ["z", false],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", false],
+    ["o2", true],
+    ["o3", false],
+    ["o4", false],
+    ["o5", false],
+    ["o6", false],
+    ["o7", false],
+  ]);
+  expect(
+    runner([
+      ["x", true],
+      ["y", true],
+      ["z", false],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", false],
+    ["o2", false],
+    ["o3", true],
+    ["o4", false],
+    ["o5", false],
+    ["o6", false],
+    ["o7", false],
+  ]);
+  expect(
+    runner([
+      ["x", false],
+      ["y", false],
+      ["z", true],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", false],
+    ["o2", false],
+    ["o3", false],
+    ["o4", true],
+    ["o5", false],
+    ["o6", false],
+    ["o7", false],
+  ]);
+  expect(
+    runner([
+      ["x", true],
+      ["y", false],
+      ["z", true],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", false],
+    ["o2", false],
+    ["o3", false],
+    ["o4", false],
+    ["o5", true],
+    ["o6", false],
+    ["o7", false],
+  ]);
+  expect(
+    runner([
+      ["x", false],
+      ["y", true],
+      ["z", true],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", false],
+    ["o2", false],
+    ["o3", false],
+    ["o4", false],
+    ["o5", false],
+    ["o6", true],
+    ["o7", false],
+  ]);
+  expect(
+    runner([
+      ["x", true],
+      ["y", true],
+      ["z", true],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", false],
+    ["o2", false],
+    ["o3", false],
+    ["o4", false],
+    ["o5", false],
+    ["o6", false],
+    ["o7", true],
+  ]);
+});
+
+test("ENC", () => {
+  const runner = getRunner(`
+    ${ENC}
+    VAR i0 BITIN
+    VAR i1 BITIN
+    VAR i2 BITIN
+    VAR i3 BITIN
+    VAR i4 BITIN
+    VAR i5 BITIN
+    VAR i6 BITIN
+    VAR i7 BITIN
+    VAR o0 BITOUT
+    VAR o1 BITOUT
+    VAR o2 BITOUT
+    VAR enc ENC
+    WIRE i0 _ TO enc i0
+    WIRE i1 _ TO enc i1
+    WIRE i2 _ TO enc i2
+    WIRE i3 _ TO enc i3
+    WIRE i4 _ TO enc i4
+    WIRE i5 _ TO enc i5
+    WIRE i6 _ TO enc i6
+    WIRE i7 _ TO enc i7
+    WIRE enc o0 TO o0 _
+    WIRE enc o1 TO o1 _
+    WIRE enc o2 TO o2 _
+  `);
+  expect(
+    runner([
+      ["i0", true],
+      ["i1", false],
+      ["i2", false],
+      ["i3", false],
+      ["i4", false],
+      ["i5", false],
+      ["i6", false],
+      ["i7", false],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", false],
+    ["o2", false],
+  ]);
+  expect(
+    runner([
+      ["i0", false],
+      ["i1", true],
+      ["i2", false],
+      ["i3", false],
+      ["i4", false],
+      ["i5", false],
+      ["i6", false],
+      ["i7", false],
+    ]),
+  ).toEqual([
+    ["o0", true],
+    ["o1", false],
+    ["o2", false],
+  ]);
+  expect(
+    runner([
+      ["i0", false],
+      ["i1", false],
+      ["i2", true],
+      ["i3", false],
+      ["i4", false],
+      ["i5", false],
+      ["i6", false],
+      ["i7", false],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", true],
+    ["o2", false],
+  ]);
+  expect(
+    runner([
+      ["i0", false],
+      ["i1", false],
+      ["i2", false],
+      ["i3", true],
+      ["i4", false],
+      ["i5", false],
+      ["i6", false],
+      ["i7", false],
+    ]),
+  ).toEqual([
+    ["o0", true],
+    ["o1", true],
+    ["o2", false],
+  ]);
+  expect(
+    runner([
+      ["i0", false],
+      ["i1", false],
+      ["i2", false],
+      ["i3", false],
+      ["i4", true],
+      ["i5", false],
+      ["i6", false],
+      ["i7", false],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", false],
+    ["o2", true],
+  ]);
+  expect(
+    runner([
+      ["i0", false],
+      ["i1", false],
+      ["i2", false],
+      ["i3", false],
+      ["i4", false],
+      ["i5", true],
+      ["i6", false],
+      ["i7", false],
+    ]),
+  ).toEqual([
+    ["o0", true],
+    ["o1", false],
+    ["o2", true],
+  ]);
+  expect(
+    runner([
+      ["i0", false],
+      ["i1", false],
+      ["i2", false],
+      ["i3", false],
+      ["i4", false],
+      ["i5", false],
+      ["i6", true],
+      ["i7", false],
+    ]),
+  ).toEqual([
+    ["o0", false],
+    ["o1", true],
+    ["o2", true],
+  ]);
+  expect(
+    runner([
+      ["i0", false],
+      ["i1", false],
+      ["i2", false],
+      ["i3", false],
+      ["i4", false],
+      ["i5", false],
+      ["i6", false],
+      ["i7", true],
+    ]),
+  ).toEqual([
+    ["o0", true],
+    ["o1", true],
+    ["o2", true],
+  ]);
+});
+
+test("BYTEIN and BYTEOUT", () => {
+  const vm = new Vm();
+  vm.compile(`
+    VAR a BYTEIN
+    VAR out BYTEOUT
+    WIRE a o0 TO out i0
+    WIRE a o1 TO out i1
+    WIRE a o2 TO out i2
+    WIRE a o3 TO out i3
+    WIRE a o4 TO out i4
+    WIRE a o5 TO out i5
+    WIRE a o6 TO out i6
+    WIRE a o7 TO out i7
+  `);
+  expect([...vm.run(new Map([["a", 0]])).entries()]).toEqual([["out", 0]]);
+  expect([...vm.run(new Map([["a", 1]])).entries()]).toEqual([["out", 1]]);
+  expect([...vm.run(new Map([["a", 42]])).entries()]).toEqual([["out", 42]]);
+  expect([...vm.run(new Map([["a", 255]])).entries()]).toEqual([["out", 255]]);
+  expect([...vm.run(new Map([["a", 128]])).entries()]).toEqual([["out", 128]]);
+});
+
+test("BYTEADD", () => {
+  const vm = new Vm();
+  vm.compile(`
+    ${BYTEADD}
+    VAR a BYTEIN
+    VAR b BYTEIN
+    VAR out BYTEOUT
+    VAR add BYTEADD
+    WIRE a o0 TO add a0
+    WIRE a o1 TO add a1
+    WIRE a o2 TO add a2
+    WIRE a o3 TO add a3
+    WIRE a o4 TO add a4
+    WIRE a o5 TO add a5
+    WIRE a o6 TO add a6
+    WIRE a o7 TO add a7
+    WIRE b o0 TO add b0
+    WIRE b o1 TO add b1
+    WIRE b o2 TO add b2
+    WIRE b o3 TO add b3
+    WIRE b o4 TO add b4
+    WIRE b o5 TO add b5
+    WIRE b o6 TO add b6
+    WIRE b o7 TO add b7
+    WIRE add o0 TO out i0
+    WIRE add o1 TO out i1
+    WIRE add o2 TO out i2
+    WIRE add o3 TO out i3
+    WIRE add o4 TO out i4
+    WIRE add o5 TO out i5
+    WIRE add o6 TO out i6
+    WIRE add o7 TO out i7
+  `);
+  expect([...vm.run(new Map([["a", 0], ["b", 0]])).entries()]).toEqual([["out", 0]]);
+  expect([...vm.run(new Map([["a", 1], ["b", 1]])).entries()]).toEqual([["out", 2]]);
+  expect([...vm.run(new Map([["a", 42], ["b", 58]])).entries()]).toEqual([["out", 100]]);
+  expect([...vm.run(new Map([["a", 127], ["b", 128]])).entries()]).toEqual([["out", 255]]);
+  // Overflow: 200 + 100 = 300 → 300 - 256 = 44
+  expect([...vm.run(new Map([["a", 200], ["b", 100]])).entries()]).toEqual([["out", 44]]);
 });
 
 test("DECODER_3BIT", () => {

--- a/packages/language/src/code-fragments.ts
+++ b/packages/language/src/code-fragments.ts
@@ -135,6 +135,216 @@ MOD START XNOR
 MOD END
 `;
 
+export const ADD = `\
+MOD START ADD
+  ${XOR}
+  ${AND}
+  ${OR}
+  VAR i0 BITIN
+  VAR i1 BITIN
+  VAR i2 BITIN
+  VAR xor0 XOR
+  WIRE i0 _ TO xor0 i0
+  WIRE i1 _ TO xor0 i1
+  VAR xor1 XOR
+  WIRE xor0 _ TO xor1 i0
+  WIRE i2 _ TO xor1 i1
+  VAR o0 BITOUT
+  WIRE xor1 _ TO o0 _
+  VAR and0 AND
+  WIRE i0 _ TO and0 i0
+  WIRE i1 _ TO and0 i1
+  VAR and1 AND
+  WIRE xor0 _ TO and1 i0
+  WIRE i2 _ TO and1 i1
+  VAR or0 OR
+  WIRE and0 _ TO or0 i0
+  WIRE and1 _ TO or0 i1
+  VAR o1 BITOUT
+  WIRE or0 _ TO o1 _
+MOD END
+`;
+
+export const DEC = `\
+MOD START DEC
+  ${NOT}
+  ${AND3}
+  VAR i0 BITIN
+  VAR i1 BITIN
+  VAR i2 BITIN
+  VAR n0 NOT
+  VAR n1 NOT
+  VAR n2 NOT
+  WIRE i0 _ TO n0 _
+  WIRE i1 _ TO n1 _
+  WIRE i2 _ TO n2 _
+  VAR a0 AND3
+  WIRE n0 _ TO a0 i0
+  WIRE n1 _ TO a0 i1
+  WIRE n2 _ TO a0 i2
+  VAR o0 BITOUT
+  WIRE a0 _ TO o0 _
+  VAR a1 AND3
+  WIRE i0 _ TO a1 i0
+  WIRE n1 _ TO a1 i1
+  WIRE n2 _ TO a1 i2
+  VAR o1 BITOUT
+  WIRE a1 _ TO o1 _
+  VAR a2 AND3
+  WIRE n0 _ TO a2 i0
+  WIRE i1 _ TO a2 i1
+  WIRE n2 _ TO a2 i2
+  VAR o2 BITOUT
+  WIRE a2 _ TO o2 _
+  VAR a3 AND3
+  WIRE i0 _ TO a3 i0
+  WIRE i1 _ TO a3 i1
+  WIRE n2 _ TO a3 i2
+  VAR o3 BITOUT
+  WIRE a3 _ TO o3 _
+  VAR a4 AND3
+  WIRE n0 _ TO a4 i0
+  WIRE n1 _ TO a4 i1
+  WIRE i2 _ TO a4 i2
+  VAR o4 BITOUT
+  WIRE a4 _ TO o4 _
+  VAR a5 AND3
+  WIRE i0 _ TO a5 i0
+  WIRE n1 _ TO a5 i1
+  WIRE i2 _ TO a5 i2
+  VAR o5 BITOUT
+  WIRE a5 _ TO o5 _
+  VAR a6 AND3
+  WIRE n0 _ TO a6 i0
+  WIRE i1 _ TO a6 i1
+  WIRE i2 _ TO a6 i2
+  VAR o6 BITOUT
+  WIRE a6 _ TO o6 _
+  VAR a7 AND3
+  WIRE i0 _ TO a7 i0
+  WIRE i1 _ TO a7 i1
+  WIRE i2 _ TO a7 i2
+  VAR o7 BITOUT
+  WIRE a7 _ TO o7 _
+MOD END
+`;
+
+export const ENC = `\
+MOD START ENC
+  ${OR}
+  VAR i0 BITIN
+  VAR i1 BITIN
+  VAR i2 BITIN
+  VAR i3 BITIN
+  VAR i4 BITIN
+  VAR i5 BITIN
+  VAR i6 BITIN
+  VAR i7 BITIN
+  VAR or00 OR
+  WIRE i1 _ TO or00 i0
+  WIRE i3 _ TO or00 i1
+  VAR or01 OR
+  WIRE i5 _ TO or01 i0
+  WIRE i7 _ TO or01 i1
+  VAR or02 OR
+  WIRE or00 _ TO or02 i0
+  WIRE or01 _ TO or02 i1
+  VAR o0 BITOUT
+  WIRE or02 _ TO o0 _
+  VAR or10 OR
+  WIRE i2 _ TO or10 i0
+  WIRE i3 _ TO or10 i1
+  VAR or11 OR
+  WIRE i6 _ TO or11 i0
+  WIRE i7 _ TO or11 i1
+  VAR or12 OR
+  WIRE or10 _ TO or12 i0
+  WIRE or11 _ TO or12 i1
+  VAR o1 BITOUT
+  WIRE or12 _ TO o1 _
+  VAR or20 OR
+  WIRE i4 _ TO or20 i0
+  WIRE i5 _ TO or20 i1
+  VAR or21 OR
+  WIRE i6 _ TO or21 i0
+  WIRE i7 _ TO or21 i1
+  VAR or22 OR
+  WIRE or20 _ TO or22 i0
+  WIRE or21 _ TO or22 i1
+  VAR o2 BITOUT
+  WIRE or22 _ TO o2 _
+MOD END
+`;
+
+export const BYTEADD = `\
+MOD START BYTEADD
+  ${ADD}
+  VAR a0 BITIN
+  VAR a1 BITIN
+  VAR a2 BITIN
+  VAR a3 BITIN
+  VAR a4 BITIN
+  VAR a5 BITIN
+  VAR a6 BITIN
+  VAR a7 BITIN
+  VAR b0 BITIN
+  VAR b1 BITIN
+  VAR b2 BITIN
+  VAR b3 BITIN
+  VAR b4 BITIN
+  VAR b5 BITIN
+  VAR b6 BITIN
+  VAR b7 BITIN
+  VAR add0 ADD
+  WIRE a0 _ TO add0 i0
+  WIRE b0 _ TO add0 i1
+  VAR add1 ADD
+  WIRE a1 _ TO add1 i0
+  WIRE b1 _ TO add1 i1
+  WIRE add0 o1 TO add1 i2
+  VAR add2 ADD
+  WIRE a2 _ TO add2 i0
+  WIRE b2 _ TO add2 i1
+  WIRE add1 o1 TO add2 i2
+  VAR add3 ADD
+  WIRE a3 _ TO add3 i0
+  WIRE b3 _ TO add3 i1
+  WIRE add2 o1 TO add3 i2
+  VAR add4 ADD
+  WIRE a4 _ TO add4 i0
+  WIRE b4 _ TO add4 i1
+  WIRE add3 o1 TO add4 i2
+  VAR add5 ADD
+  WIRE a5 _ TO add5 i0
+  WIRE b5 _ TO add5 i1
+  WIRE add4 o1 TO add5 i2
+  VAR add6 ADD
+  WIRE a6 _ TO add6 i0
+  WIRE b6 _ TO add6 i1
+  WIRE add5 o1 TO add6 i2
+  VAR add7 ADD
+  WIRE a7 _ TO add7 i0
+  WIRE b7 _ TO add7 i1
+  WIRE add6 o1 TO add7 i2
+  VAR o0 BITOUT
+  VAR o1 BITOUT
+  VAR o2 BITOUT
+  VAR o3 BITOUT
+  VAR o4 BITOUT
+  VAR o5 BITOUT
+  VAR o6 BITOUT
+  VAR o7 BITOUT
+  WIRE add0 o0 TO o0 _
+  WIRE add1 o0 TO o1 _
+  WIRE add2 o0 TO o2 _
+  WIRE add3 o0 TO o3 _
+  WIRE add4 o0 TO o4 _
+  WIRE add5 o0 TO o5 _
+  WIRE add6 o0 TO o6 _
+  WIRE add7 o0 TO o7 _
+MOD END
+`;
+
 export const DECODER_3BIT = `\
 MOD START DECODER_3BIT
   ${NOT}

--- a/packages/language/src/internal-model/module.ts
+++ b/packages/language/src/internal-model/module.ts
@@ -44,6 +44,30 @@ export class BitoutModule implements Module {
   }
 }
 
+export class ByteinModule implements Module {
+  public readonly name = "BYTEIN";
+
+  public createVariable(varName: string): Variable {
+    const outPorts = new Map<string, Reactive<boolean>>();
+    for (let i = 0; i < 8; i++) {
+      outPorts.set(`o${i}`, reactive(false));
+    }
+    return new Variable(varName, new Map(), outPorts);
+  }
+}
+
+export class ByteoutModule implements Module {
+  public readonly name = "BYTEOUT";
+
+  public createVariable(varName: string): Variable {
+    const inPorts = new Map<string, Reactive<boolean>>();
+    for (let i = 0; i < 8; i++) {
+      inPorts.set(`i${i}`, reactive(false));
+    }
+    return new Variable(varName, inPorts, new Map());
+  }
+}
+
 export class FlipflopModule implements Module {
   public readonly name = "FLIPFLOP";
 
@@ -84,6 +108,8 @@ export const createModule = (
       const variables: Variable[] = [];
       const bitIns = new Map<string, Reactive<boolean>>();
       const bitOuts = new Map<string, Reactive<boolean>>();
+      const byteIns = new Map<string, Reactive<boolean>[]>();
+      const byteOuts = new Map<string, Reactive<boolean>[]>();
       for (const statement of moduleStatement.definitionStatements) {
         if (statement.subtype.type === "varStatement") {
           const moduleName = statement.subtype.moduleName;
@@ -106,6 +132,22 @@ export const createModule = (
             const port = variable.inPorts.get("i0");
             invariant(port, "Can't find port i0 of BITIN");
             bitOuts.set(variable.name, port);
+          } else if (module instanceof ByteinModule) {
+            const ports: Reactive<boolean>[] = [];
+            for (let i = 0; i < 8; i++) {
+              const port = variable.outPorts.get(`o${i}`);
+              invariant(port, `Can't find port o${i} of BYTEIN`);
+              ports.push(port);
+            }
+            byteIns.set(variable.name, ports);
+          } else if (module instanceof ByteoutModule) {
+            const ports: Reactive<boolean>[] = [];
+            for (let i = 0; i < 8; i++) {
+              const port = variable.inPorts.get(`i${i}`);
+              invariant(port, `Can't find port i${i} of BYTEOUT`);
+              ports.push(port);
+            }
+            byteOuts.set(variable.name, ports);
           }
         } else if (statement.subtype.type === "wireStatement") {
           const {
@@ -170,7 +212,7 @@ export const createModule = (
         }
       }
 
-      return new Variable(varName, bitIns, bitOuts, variables);
+      return new Variable(varName, bitIns, bitOuts, variables, byteIns, byteOuts);
     }
   };
   Object.defineProperty(C, "name", { value: moduleStatement.name });

--- a/packages/language/src/internal-model/program.ts
+++ b/packages/language/src/internal-model/program.ts
@@ -1,5 +1,5 @@
 import { Program as ProgramAst } from "../parser/ast";
-import { BitinModule, BitoutModule, createModule, FlipflopModule, NandModule } from "./module";
+import { BitinModule, BitoutModule, ByteinModule, ByteoutModule, createModule, FlipflopModule, NandModule } from "./module";
 import { Variable } from "./variable";
 
 export class Program {
@@ -12,19 +12,36 @@ export class Program {
         name: "Program",
         definitionStatements: this.programAst.statements,
       },
-      [new NandModule(), new BitinModule(), new BitoutModule(), new FlipflopModule()],
+      [new NandModule(), new BitinModule(), new BitoutModule(), new ByteinModule(), new ByteoutModule(), new FlipflopModule()],
     );
     this.variable = new ProgramModule().createVariable("PROGRAM");
   }
 
-  public run(inputSignals: Map<string, boolean>): Map<string, boolean> {
+  public run(inputSignals: Map<string, boolean | number>): Map<string, boolean | number> {
     for (const [name, value] of inputSignals.entries()) {
-      this.variable.inPorts.get(name)?.set(() => value);
+      if (typeof value === "boolean") {
+        this.variable.inPorts.get(name)?.set(() => value);
+      } else {
+        const ports = this.variable.byteInPorts.get(name);
+        if (ports) {
+          for (let i = 0; i < 8; i++) {
+            const bit = ((value >> i) & 1) === 1;
+            ports[i].set(() => bit);
+          }
+        }
+      }
     }
 
-    const outputSignals = new Map<string, boolean>();
+    const outputSignals = new Map<string, boolean | number>();
     for (const [name, port] of this.variable.outPorts.entries()) {
       outputSignals.set(name, port.value);
+    }
+    for (const [name, ports] of this.variable.byteOutPorts.entries()) {
+      let value = 0;
+      for (let i = 0; i < 8; i++) {
+        if (ports[i].value) value |= (1 << i);
+      }
+      outputSignals.set(name, value);
     }
 
     return outputSignals;

--- a/packages/language/src/internal-model/variable.ts
+++ b/packages/language/src/internal-model/variable.ts
@@ -7,5 +7,7 @@ export class Variable {
     public readonly inPorts: Map<string, Reactive<boolean>>,
     public readonly outPorts: Map<string, Reactive<boolean>>,
     public readonly children: Variable[] = [],
+    public readonly byteInPorts: Map<string, Reactive<boolean>[]> = new Map(),
+    public readonly byteOutPorts: Map<string, Reactive<boolean>[]> = new Map(),
   ) {}
 }

--- a/packages/language/src/vm.ts
+++ b/packages/language/src/vm.ts
@@ -14,7 +14,7 @@ export class Vm {
     this.program = new Program(parseResult.data);
   }
 
-  public run(inputSignals: Map<string, boolean>): Map<string, boolean> {
+  public run(inputSignals: Map<string, boolean | number>): Map<string, boolean | number> {
     if (this.program == null) throw new Error(`No program compiled to run`);
     return this.program.run(inputSignals);
   }

--- a/packages/viewer/src/components/CircuitDiagramPanel.tsx
+++ b/packages/viewer/src/components/CircuitDiagramPanel.tsx
@@ -14,6 +14,8 @@ import {
 import "@xyflow/react/dist/style.css";
 import { BitinNode } from "./nodes/BitinNode";
 import { BitoutNode } from "./nodes/BitoutNode";
+import { ByteinNode } from "./nodes/ByteinNode";
+import { ByteoutNode } from "./nodes/ByteoutNode";
 import { NandNode } from "./nodes/NandNode";
 import { FlipflopNode } from "./nodes/FlipflopNode";
 import { ModuleNode } from "./nodes/ModuleNode";
@@ -22,6 +24,8 @@ import type { NodeData } from "../lib/astToGraph";
 const nodeTypes: NodeTypes = {
   bitinNode: BitinNode,
   bitoutNode: BitoutNode,
+  byteinNode: ByteinNode,
+  byteoutNode: ByteoutNode,
   nandNode: NandNode,
   flipflopNode: FlipflopNode,
   moduleNode: ModuleNode,

--- a/packages/viewer/src/components/HelpManual.tsx
+++ b/packages/viewer/src/components/HelpManual.tsx
@@ -379,6 +379,183 @@ VAR x NOT`}</pre>
       </>
     ),
   },
+  {
+    id: "mod-bytein",
+    title: "BYTEIN: バイト入力",
+    content: (
+      <>
+        <p>
+          0〜255の整数を受け取り、8ビットに分解して出力するモジュールです。
+          ビット0（o0）がLSB（最下位ビット）、ビット7（o7）がMSBです。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>o0</code></td><td>出力</td><td>ビット0（1の位）</td></tr>
+            <tr><td><code>o1</code></td><td>出力</td><td>ビット1（2の位）</td></tr>
+            <tr><td><code>o2</code></td><td>出力</td><td>ビット2（4の位）</td></tr>
+            <tr><td><code>o3</code>〜<code>o7</code></td><td>出力</td><td>ビット3〜7</td></tr>
+          </tbody>
+        </table>
+        <p>例: 値が42（= 00101010）のとき、o1=1, o3=1, o5=1、他は0</p>
+      </>
+    ),
+  },
+  {
+    id: "mod-byteout",
+    title: "BYTEOUT: バイト出力",
+    content: (
+      <>
+        <p>
+          8本のビット入力を受け取り、整数（0〜255）に組み立てて出力するモジュールです。
+          BYTEINの逆の動作をします。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>i0</code></td><td>入力</td><td>ビット0（1の位）</td></tr>
+            <tr><td><code>i1</code></td><td>入力</td><td>ビット1（2の位）</td></tr>
+            <tr><td><code>i2</code></td><td>入力</td><td>ビット2（4の位）</td></tr>
+            <tr><td><code>i3</code>〜<code>i7</code></td><td>入力</td><td>ビット3〜7</td></tr>
+          </tbody>
+        </table>
+        <p>出力値 = i0×1 + i1×2 + i2×4 + i3×8 + ... + i7×128</p>
+      </>
+    ),
+  },
+  {
+    id: "circuit-half-adder",
+    title: "Half Adder: 半加算器",
+    content: (
+      <>
+        <p>
+          1ビット同士の足し算を行う回路です。
+          2つの入力a, bの和をs（Sum: 合計）とc（Carry: 繰り上がり）で表します。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>a</code>, <code>b</code></td><td>入力</td><td>足し合わせる2つのビット</td></tr>
+            <tr><td><code>s</code></td><td>出力</td><td>合計（Sum）</td></tr>
+            <tr><td><code>c</code></td><td>出力</td><td>繰り上がり（Carry）</td></tr>
+          </tbody>
+        </table>
+        <p>真理値表:</p>
+        <table>
+          <thead>
+            <tr><th>a</th><th>b</th><th>s</th><th>c</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+            <tr><td>0</td><td>1</td><td>1</td><td>0</td></tr>
+            <tr><td>1</td><td>0</td><td>1</td><td>0</td></tr>
+            <tr><td>1</td><td>1</td><td>0</td><td>1</td></tr>
+          </tbody>
+        </table>
+        <details>
+          <summary>ヒント</summary>
+          <p>sの真理値表はXOR、cの真理値表はANDと同じです。</p>
+        </details>
+      </>
+    ),
+  },
+  {
+    id: "circuit-full-adder",
+    title: "Full Adder: 全加算器（ADD）",
+    content: (
+      <>
+        <p>
+          下の桁からの繰り上がり（cin）も含めた1ビットの足し算を行います。
+          Full Adderを連結すれば多ビットの足し算が可能です。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>i0</code></td><td>入力</td><td>入力A</td></tr>
+            <tr><td><code>i1</code></td><td>入力</td><td>入力B</td></tr>
+            <tr><td><code>i2</code></td><td>入力</td><td>繰り上がり入力（Carry In）</td></tr>
+            <tr><td><code>o0</code></td><td>出力</td><td>合計（Sum）</td></tr>
+            <tr><td><code>o1</code></td><td>出力</td><td>繰り上がり出力（Carry Out）</td></tr>
+          </tbody>
+        </table>
+        <details>
+          <summary>ヒント</summary>
+          <p>
+            Half Adderを2段使います。まずa XOR bで仮の合計を出し、
+            それとcinをもう一度XOR。繰り上がりは (a AND b) OR (仮の合計 AND cin) です。
+          </p>
+        </details>
+      </>
+    ),
+  },
+  {
+    id: "circuit-decoder",
+    title: "Decoder: デコーダ（DEC）",
+    content: (
+      <>
+        <p>
+          3ビットの2進数入力を解読し、対応する8本の出力線の1つだけを有効にします。
+          メモリのアドレス指定やマルチプレクサの制御に使われます。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>i0</code></td><td>入力</td><td>ビット0（LSB）</td></tr>
+            <tr><td><code>i1</code></td><td>入力</td><td>ビット1</td></tr>
+            <tr><td><code>i2</code></td><td>入力</td><td>ビット2（MSB）</td></tr>
+            <tr><td><code>o0</code>〜<code>o7</code></td><td>出力</td><td>デコード結果（1つだけ1）</td></tr>
+          </tbody>
+        </table>
+        <details>
+          <summary>ヒント</summary>
+          <p>
+            各出力はAND3で実現します。入力が0であるべき箇所にはNOTを通してから接続します。
+            例: o5（= 101）は i0 AND NOT(i1) AND i2 です。
+          </p>
+        </details>
+      </>
+    ),
+  },
+  {
+    id: "circuit-encoder",
+    title: "Encoder: エンコーダ（ENC）",
+    content: (
+      <>
+        <p>
+          デコーダの逆の動作をします。8本の入力線のうち1本が有効なとき、
+          その番号を3ビットの2進数で出力します。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>i0</code>〜<code>i7</code></td><td>入力</td><td>8本の入力（1本だけ1）</td></tr>
+            <tr><td><code>o0</code></td><td>出力</td><td>ビット0（LSB）</td></tr>
+            <tr><td><code>o1</code></td><td>出力</td><td>ビット1</td></tr>
+            <tr><td><code>o2</code></td><td>出力</td><td>ビット2（MSB）</td></tr>
+          </tbody>
+        </table>
+        <details>
+          <summary>ヒント</summary>
+          <p>
+            各出力ビットは、そのビットが1になる入力線すべてのORです。
+            例: o0は奇数番号の入力（i1, i3, i5, i7）のOR。
+          </p>
+        </details>
+      </>
+    ),
+  },
 ];
 
 export function HelpManual({ onClose, highlightSections }: Props) {

--- a/packages/viewer/src/components/TestCasePanel.tsx
+++ b/packages/viewer/src/components/TestCasePanel.tsx
@@ -22,9 +22,16 @@ function BitValue({
   value,
   className,
 }: {
-  value: boolean;
+  value: boolean | number;
   className?: string;
 }) {
+  if (typeof value === "number") {
+    return (
+      <span className={`bit-value byte-value ${className ?? ""}`}>
+        {value}
+      </span>
+    );
+  }
   return (
     <span
       className={`bit-value ${value ? "bit-on" : "bit-off"} ${className ?? ""}`}
@@ -38,9 +45,16 @@ function BitDisplay({
   value,
   match,
 }: {
-  value: boolean;
+  value: boolean | number;
   match: boolean;
 }) {
+  if (typeof value === "number") {
+    return (
+      <span className={`bit-display ${match ? "" : "bit-mismatch"}`}>
+        {value}
+      </span>
+    );
+  }
   return (
     <span className={`bit-display ${match ? "" : "bit-mismatch"}`}>
       {value ? "1" : "0"}
@@ -108,7 +122,7 @@ export function TestCasePanel({
                   <th className="row-header input-header">{name}</th>
                   {testCases.map((tc, i) => (
                     <td key={i} className={`test-col-${tc.status}`}>
-                      <BitValue value={tc.inputs.get(name) ?? false} />
+                      <BitValue value={tc.inputs.get(name) ?? 0} />
                     </td>
                   ))}
                 </tr>
@@ -122,7 +136,7 @@ export function TestCasePanel({
                   {testCases.map((tc, i) => (
                     <td key={i} className={`test-col-${tc.status}`}>
                       <BitValue
-                        value={tc.expectedOutputs.get(name) ?? false}
+                        value={tc.expectedOutputs.get(name) ?? 0}
                         className="expected-bit"
                       />
                     </td>
@@ -139,7 +153,7 @@ export function TestCasePanel({
                     <td key={i} className={`test-col-${tc.status}`}>
                       {tc.actualOutputs ? (
                         <BitDisplay
-                          value={tc.actualOutputs.get(name) ?? false}
+                          value={tc.actualOutputs.get(name) ?? 0}
                           match={
                             tc.actualOutputs.get(name) ===
                             tc.expectedOutputs.get(name)

--- a/packages/viewer/src/components/nodes/ByteinNode.tsx
+++ b/packages/viewer/src/components/nodes/ByteinNode.tsx
@@ -1,0 +1,29 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { NodeData } from "../../lib/astToGraph";
+import "./nodeStyles.css";
+
+const PORTS = ["o0", "o1", "o2", "o3", "o4", "o5", "o6", "o7"];
+
+export function ByteinNode({ data }: NodeProps & { data: NodeData }) {
+  const value = typeof data.value === "number" ? data.value : 0;
+  return (
+    <div className="circuit-node bytein-node">
+      <div className="node-label">{data.label}</div>
+      <div className="node-type">BYTEIN</div>
+      <div className="byte-value-display">{value}</div>
+      <div className="byte-ports">
+        {PORTS.map((port, i) => (
+          <div key={port} className="byte-port-row byte-port-out">
+            <span className="port-label">{port}</span>
+            <Handle
+              type="source"
+              position={Position.Right}
+              id={port}
+              style={{ top: `${((i + 1) / (PORTS.length + 1)) * 100}%` }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/viewer/src/components/nodes/ByteoutNode.tsx
+++ b/packages/viewer/src/components/nodes/ByteoutNode.tsx
@@ -1,0 +1,29 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { NodeData } from "../../lib/astToGraph";
+import "./nodeStyles.css";
+
+const PORTS = ["i0", "i1", "i2", "i3", "i4", "i5", "i6", "i7"];
+
+export function ByteoutNode({ data }: NodeProps & { data: NodeData }) {
+  const value = typeof data.value === "number" ? data.value : 0;
+  return (
+    <div className="circuit-node byteout-node">
+      <div className="byte-value-display">{value}</div>
+      <div className="byte-ports">
+        {PORTS.map((port, i) => (
+          <div key={port} className="byte-port-row byte-port-in">
+            <Handle
+              type="target"
+              position={Position.Left}
+              id={port}
+              style={{ top: `${((i + 1) / (PORTS.length + 1)) * 100}%` }}
+            />
+            <span className="port-label">{port}</span>
+          </div>
+        ))}
+      </div>
+      <div className="node-label">{data.label}</div>
+      <div className="node-type">BYTEOUT</div>
+    </div>
+  );
+}

--- a/packages/viewer/src/components/nodes/nodeStyles.css
+++ b/packages/viewer/src/components/nodes/nodeStyles.css
@@ -56,6 +56,47 @@
   border-color: #22c55e;
 }
 
+.bytein-node {
+  border-color: #4a9eff;
+  min-height: 180px;
+}
+
+.byteout-node {
+  border-color: #ff6b6b;
+  min-height: 180px;
+}
+
+.byte-value-display {
+  font-size: 18px;
+  font-weight: bold;
+  color: #fff;
+  text-align: center;
+  margin: 4px 0;
+  padding: 2px 8px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+.byte-ports {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 4px;
+}
+
+.byte-port-row {
+  font-size: 9px;
+  color: #aaa;
+}
+
+.byte-port-out {
+  text-align: right;
+}
+
+.byte-port-in {
+  text-align: left;
+}
+
 .port-label {
   font-size: 9px;
   color: #aaa;

--- a/packages/viewer/src/hooks/useCircuit.ts
+++ b/packages/viewer/src/hooks/useCircuit.ts
@@ -9,10 +9,10 @@ export function useCircuit() {
   const [edges, setEdges] = useState<Edge[]>([]);
   const [inputNames, setInputNames] = useState<string[]>([]);
   const [outputNames, setOutputNames] = useState<string[]>([]);
-  const [inputSignals, setInputSignals] = useState<Map<string, boolean>>(
+  const [inputSignals, setInputSignals] = useState<Map<string, boolean | number>>(
     new Map(),
   );
-  const [outputSignals, setOutputSignals] = useState<Map<string, boolean>>(
+  const [outputSignals, setOutputSignals] = useState<Map<string, boolean | number>>(
     new Map(),
   );
   const [error, setError] = useState<string | null>(null);
@@ -33,9 +33,10 @@ export function useCircuit() {
       setInputNames(graph.inputNames);
       setOutputNames(graph.outputNames);
 
-      const initialInputs = new Map<string, boolean>();
-      for (const name of graph.inputNames) {
-        initialInputs.set(name, false);
+      const initialInputs = new Map<string, boolean | number>();
+      for (const node of graph.nodes) {
+        if (node.data.moduleName === "BITIN") initialInputs.set(node.id, false);
+        else if (node.data.moduleName === "BYTEIN") initialInputs.set(node.id, 0);
       }
       setInputSignals(initialInputs);
 
@@ -53,6 +54,12 @@ export function useCircuit() {
         }
         if (node.data.moduleName === "BITIN") {
           return { ...node, data: { ...node.data, value: false } };
+        }
+        if (node.data.moduleName === "BYTEOUT") {
+          return { ...node, data: { ...node.data, value: outputs.get(node.id) ?? 0 } };
+        }
+        if (node.data.moduleName === "BYTEIN") {
+          return { ...node, data: { ...node.data, value: 0 } };
         }
         return node;
       });
@@ -89,6 +96,18 @@ export function useCircuit() {
                     data: { ...node.data, value: next.get(node.id) ?? false },
                   };
                 }
+                if (node.data.moduleName === "BYTEOUT") {
+                  return {
+                    ...node,
+                    data: { ...node.data, value: outputs.get(node.id) ?? 0 },
+                  };
+                }
+                if (node.data.moduleName === "BYTEIN") {
+                  return {
+                    ...node,
+                    data: { ...node.data, value: next.get(node.id) ?? 0 },
+                  };
+                }
                 return node;
               }),
             );
@@ -105,8 +124,8 @@ export function useCircuit() {
 
   const updateNodeSignals = useCallback(
     (
-      inputs: Map<string, boolean>,
-      outputs: Map<string, boolean>,
+      inputs: Map<string, boolean | number>,
+      outputs: Map<string, boolean | number>,
       allSignals: Map<string, boolean>,
     ) => {
       setNodes((prevNodes) =>
@@ -121,6 +140,18 @@ export function useCircuit() {
             return {
               ...node,
               data: { ...node.data, value: outputs.get(node.id) ?? false },
+            };
+          }
+          if (node.data.moduleName === "BYTEIN") {
+            return {
+              ...node,
+              data: { ...node.data, value: inputs.get(node.id) ?? 0 },
+            };
+          }
+          if (node.data.moduleName === "BYTEOUT") {
+            return {
+              ...node,
+              data: { ...node.data, value: outputs.get(node.id) ?? 0 },
             };
           }
           if (node.data.moduleName === "FLIPFLOP") {

--- a/packages/viewer/src/hooks/useTestCases.ts
+++ b/packages/viewer/src/hooks/useTestCases.ts
@@ -3,15 +3,15 @@ import { Vm } from "@nandlang-ts/language/vm";
 import type { PuzzleTestCase } from "../lib/puzzles";
 
 export type TestCase = {
-  inputs: Map<string, boolean>;
-  expectedOutputs: Map<string, boolean>;
-  actualOutputs: Map<string, boolean> | null;
+  inputs: Map<string, boolean | number>;
+  expectedOutputs: Map<string, boolean | number>;
+  actualOutputs: Map<string, boolean | number> | null;
   status: "idle" | "pass" | "fail";
 };
 
 type OnTestRun = (
-  inputs: Map<string, boolean>,
-  outputs: Map<string, boolean>,
+  inputs: Map<string, boolean | number>,
+  outputs: Map<string, boolean | number>,
   allSignals: Map<string, boolean>,
 ) => void;
 

--- a/packages/viewer/src/language.d.ts
+++ b/packages/viewer/src/language.d.ts
@@ -1,7 +1,7 @@
 declare module "@nandlang-ts/language/vm" {
   export class Vm {
     compile(programString: string): void;
-    run(inputSignals: Map<string, boolean>): Map<string, boolean>;
+    run(inputSignals: Map<string, boolean | number>): Map<string, boolean | number>;
     getAllSignals(): Map<string, boolean>;
   }
 }
@@ -52,5 +52,9 @@ declare module "@nandlang-ts/language/code-fragments" {
   export const NOR: string;
   export const XOR: string;
   export const XNOR: string;
+  export const ADD: string;
+  export const DEC: string;
+  export const ENC: string;
+  export const BYTEADD: string;
   export const DECODER_3BIT: string;
 }

--- a/packages/viewer/src/lib/astToGraph.ts
+++ b/packages/viewer/src/lib/astToGraph.ts
@@ -8,6 +8,8 @@ const BUILTIN_PORTS: Record<string, PortInfo> = {
   NAND: { inputs: ["i0", "i1"], outputs: ["o0"] },
   BITIN: { inputs: [], outputs: ["o0"] },
   BITOUT: { inputs: ["i0"], outputs: [] },
+  BYTEIN: { inputs: [], outputs: ["o0", "o1", "o2", "o3", "o4", "o5", "o6", "o7"] },
+  BYTEOUT: { inputs: ["i0", "i1", "i2", "i3", "i4", "i5", "i6", "i7"], outputs: [] },
   FLIPFLOP: { inputs: ["s", "r"], outputs: ["q"] },
 };
 
@@ -59,7 +61,7 @@ export type NodeData = {
   moduleName: string;
   inputs: string[];
   outputs: string[];
-  value?: boolean;
+  value?: boolean | number;
 };
 
 export function astToGraph(ast: Program): {
@@ -91,12 +93,14 @@ export function astToGraph(ast: Program): {
     const ports = resolveModulePorts(st.moduleName, moduleDefs);
     varPorts.set(st.variableName, ports);
 
-    if (st.moduleName === "BITIN") inputNames.push(st.variableName);
-    if (st.moduleName === "BITOUT") outputNames.push(st.variableName);
+    if (st.moduleName === "BITIN" || st.moduleName === "BYTEIN") inputNames.push(st.variableName);
+    if (st.moduleName === "BITOUT" || st.moduleName === "BYTEOUT") outputNames.push(st.variableName);
 
     let nodeType: string;
     if (st.moduleName === "BITIN") nodeType = "bitinNode";
     else if (st.moduleName === "BITOUT") nodeType = "bitoutNode";
+    else if (st.moduleName === "BYTEIN") nodeType = "byteinNode";
+    else if (st.moduleName === "BYTEOUT") nodeType = "byteoutNode";
     else if (st.moduleName === "NAND") nodeType = "nandNode";
     else if (st.moduleName === "FLIPFLOP") nodeType = "flipflopNode";
     else nodeType = "moduleNode";
@@ -147,7 +151,8 @@ export function astToGraph(ast: Program): {
   g.setDefaultEdgeLabel(() => ({}));
 
   for (const node of nodes) {
-    g.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+    const isByte = node.type === "byteinNode" || node.type === "byteoutNode";
+    g.setNode(node.id, { width: NODE_WIDTH, height: isByte ? 200 : NODE_HEIGHT });
   }
   for (const edge of edges) {
     g.setEdge(edge.source, edge.target);

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -6,11 +6,15 @@ import {
   XOR,
   XNOR,
   AND3,
+  OR3,
+  ADD,
+  DEC,
+  ENC,
 } from "@nandlang-ts/language/code-fragments";
 
 export type PuzzleTestCase = {
-  inputs: Map<string, boolean>;
-  expectedOutputs: Map<string, boolean>;
+  inputs: Map<string, boolean | number>;
+  expectedOutputs: Map<string, boolean | number>;
 };
 
 export type Puzzle = {
@@ -31,8 +35,8 @@ export type Puzzle = {
 };
 
 function tc(
-  inputs: Record<string, boolean>,
-  expectedOutputs: Record<string, boolean>,
+  inputs: Record<string, boolean | number>,
+  expectedOutputs: Record<string, boolean | number>,
 ): PuzzleTestCase {
   return {
     inputs: new Map(Object.entries(inputs)),
@@ -306,5 +310,295 @@ WIRE o1 _ TO out _
 `,
     availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3"],
     helpSections: ["gate-or"],
+  },
+  {
+    id: 12,
+    title: "Lv12: Half Adder",
+    description:
+      "コンピュータの計算の基本、2進数の足し算を回路で実現しましょう！\n\n" +
+      "私たちが普段使う10進数の足し算（例: 7+5=12）では、1桁に収まらないとき繰り上がりが発生します。" +
+      "2進数でも同じです。1ビット同士の足し算では:\n" +
+      "  0+0=0, 0+1=1, 1+0=1, 1+1=10（繰り上がり）\n\n" +
+      "Half Adder（半加算器）は、この1ビット同士の足し算を行う回路です。" +
+      "結果は2つの出力で表します:\n" +
+      "  s（Sum）= 足し算の結果の1の位\n" +
+      "  c（Carry）= 繰り上がり（桁上げ）\n\n" +
+      "例えば 1+1 の場合、2進数で 10 なので s=0, c=1 となります。\n" +
+      "これまで学んだゲートの中に、この動作にぴったりなものがあるはずです。",
+    inputNames: ["a", "b"],
+    outputNames: ["s", "c"],
+    testCases: [
+      tc({ a: false, b: false }, { s: false, c: false }),
+      tc({ a: false, b: true }, { s: true, c: false }),
+      tc({ a: true, b: false }, { s: true, c: false }),
+      tc({ a: true, b: true }, { s: false, c: true }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}`,
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR s BITOUT\nVAR c BITOUT`,
+    editableCode: `VAR xor XOR
+VAR and AND
+WIRE a _ TO xor i0
+WIRE b _ TO xor i1
+WIRE xor _ TO s _
+WIRE a _ TO and i0
+WIRE b _ TO and i1
+WIRE and _ TO c _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3"],
+    helpSections: ["circuit-half-adder"],
+  },
+  {
+    id: 13,
+    title: "Lv13: Full Adder",
+    description:
+      "Half Adderでは1ビット同士の足し算ができましたが、複数桁の足し算には対応できません。\n\n" +
+      "例えば2桁の2進数 11+01 を計算するとき、1の位の 1+1=10 で繰り上がりが発生し、" +
+      "2の位では 1+0 に加えて繰り上がりの 1 も足す必要があります。\n\n" +
+      "Full Adder（全加算器）は、2つの入力 a, b に加えて下の桁からの繰り上がり cin も受け取り、" +
+      "3つの値の合計を計算します。出力は:\n" +
+      "  s（Sum）= 合計の1の位\n" +
+      "  cout（Carry Out）= 上の桁への繰り上がり\n\n" +
+      "Full Adderを連結すれば、何桁でも足し算できます。" +
+      "例えば8個のFull Adderを繋げれば8ビット（0〜255）の足し算が可能です。\n\n" +
+      "ヒント: Half Adderの考え方を2段階に適用してみましょう。" +
+      "まずaとbを足し、その結果にcinを足します。繰り上がりはどちらかの段で発生すればOKです。",
+    inputNames: ["a", "b", "cin"],
+    outputNames: ["s", "cout"],
+    testCases: [
+      tc({ a: false, b: false, cin: false }, { s: false, cout: false }),
+      tc({ a: false, b: false, cin: true }, { s: true, cout: false }),
+      tc({ a: false, b: true, cin: false }, { s: true, cout: false }),
+      tc({ a: false, b: true, cin: true }, { s: false, cout: true }),
+      tc({ a: true, b: false, cin: false }, { s: true, cout: false }),
+      tc({ a: true, b: false, cin: true }, { s: false, cout: true }),
+      tc({ a: true, b: true, cin: false }, { s: false, cout: true }),
+      tc({ a: true, b: true, cin: true }, { s: true, cout: true }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}`,
+    fixedCode: `VAR a BITIN\nVAR b BITIN\nVAR cin BITIN\nVAR s BITOUT\nVAR cout BITOUT`,
+    editableCode: `VAR xor0 XOR
+VAR xor1 XOR
+WIRE a _ TO xor0 i0
+WIRE b _ TO xor0 i1
+WIRE xor0 _ TO xor1 i0
+WIRE cin _ TO xor1 i1
+WIRE xor1 _ TO s _
+VAR and0 AND
+WIRE a _ TO and0 i0
+WIRE b _ TO and0 i1
+VAR and1 AND
+WIRE xor0 _ TO and1 i0
+WIRE cin _ TO and1 i1
+VAR or0 OR
+WIRE and0 _ TO or0 i0
+WIRE and1 _ TO or0 i1
+WIRE or0 _ TO cout _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3"],
+    helpSections: ["circuit-half-adder", "circuit-full-adder"],
+  },
+  {
+    id: 14,
+    title: "Lv14: Decoder",
+    description:
+      "デコーダは、2進数の入力パターンを解読して、対応する1本の出力線だけを有効にする回路です。\n\n" +
+      "3ビットの入力（i0, i1, i2）は 0〜7 の8通りの値を表現できます。" +
+      "デコーダはこの値に対応する出力（o0〜o7）のうち1つだけを1にします。\n" +
+      "例: i0=1, i1=0, i2=1（2進数で 101 = 10進数で5）→ o5だけが1\n\n" +
+      "各出力は「3つの入力がすべて特定の値であるか」を判定するAND回路です。" +
+      "入力が0であるべき箇所にはNOTを通してからANDに入れます。",
+    inputNames: ["i0", "i1", "i2"],
+    outputNames: ["o0", "o1", "o2", "o3", "o4", "o5", "o6", "o7"],
+    testCases: [
+      tc({ i0: false, i1: false, i2: false }, { o0: true, o1: false, o2: false, o3: false, o4: false, o5: false, o6: false, o7: false }),
+      tc({ i0: true, i1: false, i2: false }, { o0: false, o1: true, o2: false, o3: false, o4: false, o5: false, o6: false, o7: false }),
+      tc({ i0: false, i1: true, i2: false }, { o0: false, o1: false, o2: true, o3: false, o4: false, o5: false, o6: false, o7: false }),
+      tc({ i0: true, i1: true, i2: false }, { o0: false, o1: false, o2: false, o3: true, o4: false, o5: false, o6: false, o7: false }),
+      tc({ i0: false, i1: false, i2: true }, { o0: false, o1: false, o2: false, o3: false, o4: true, o5: false, o6: false, o7: false }),
+      tc({ i0: true, i1: false, i2: true }, { o0: false, o1: false, o2: false, o3: false, o4: false, o5: true, o6: false, o7: false }),
+      tc({ i0: false, i1: true, i2: true }, { o0: false, o1: false, o2: false, o3: false, o4: false, o5: false, o6: true, o7: false }),
+      tc({ i0: true, i1: true, i2: true }, { o0: false, o1: false, o2: false, o3: false, o4: false, o5: false, o6: false, o7: true }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${ADD}`,
+    fixedCode: `VAR i0 BITIN\nVAR i1 BITIN\nVAR i2 BITIN\nVAR o0 BITOUT\nVAR o1 BITOUT\nVAR o2 BITOUT\nVAR o3 BITOUT\nVAR o4 BITOUT\nVAR o5 BITOUT\nVAR o6 BITOUT\nVAR o7 BITOUT`,
+    editableCode: `VAR n0 NOT
+VAR n1 NOT
+VAR n2 NOT
+WIRE i0 _ TO n0 _
+WIRE i1 _ TO n1 _
+WIRE i2 _ TO n2 _
+VAR a0 AND3
+WIRE n0 _ TO a0 i0
+WIRE n1 _ TO a0 i1
+WIRE n2 _ TO a0 i2
+WIRE a0 _ TO o0 _
+VAR a1 AND3
+WIRE i0 _ TO a1 i0
+WIRE n1 _ TO a1 i1
+WIRE n2 _ TO a1 i2
+WIRE a1 _ TO o1 _
+VAR a2 AND3
+WIRE n0 _ TO a2 i0
+WIRE i1 _ TO a2 i1
+WIRE n2 _ TO a2 i2
+WIRE a2 _ TO o2 _
+VAR a3 AND3
+WIRE i0 _ TO a3 i0
+WIRE i1 _ TO a3 i1
+WIRE n2 _ TO a3 i2
+WIRE a3 _ TO o3 _
+VAR a4 AND3
+WIRE n0 _ TO a4 i0
+WIRE n1 _ TO a4 i1
+WIRE i2 _ TO a4 i2
+WIRE a4 _ TO o4 _
+VAR a5 AND3
+WIRE i0 _ TO a5 i0
+WIRE n1 _ TO a5 i1
+WIRE i2 _ TO a5 i2
+WIRE a5 _ TO o5 _
+VAR a6 AND3
+WIRE n0 _ TO a6 i0
+WIRE i1 _ TO a6 i1
+WIRE i2 _ TO a6 i2
+WIRE a6 _ TO o6 _
+VAR a7 AND3
+WIRE i0 _ TO a7 i0
+WIRE i1 _ TO a7 i1
+WIRE i2 _ TO a7 i2
+WIRE a7 _ TO o7 _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD"],
+    helpSections: ["circuit-decoder"],
+  },
+  {
+    id: 15,
+    title: "Lv15: Encoder",
+    description:
+      "エンコーダはデコーダの逆です。8本の入力線のうち1本だけが有効なとき、" +
+      "どの線が有効かを3ビットの2進数で出力します。\n\n" +
+      "例: i5だけが1 → o0=1, o1=0, o2=1（2進数で 101 = 10進数で5）\n\n" +
+      "各出力ビットは、そのビットが1になる入力線すべてのORを取ります:\n" +
+      "  o0（1の位）= i1 OR i3 OR i5 OR i7\n" +
+      "  o1（2の位）= i2 OR i3 OR i6 OR i7\n" +
+      "  o2（4の位）= i4 OR i5 OR i6 OR i7\n\n" +
+      "テストケースでは、常に入力のうち1本だけが1になります。",
+    inputNames: ["i0", "i1", "i2", "i3", "i4", "i5", "i6", "i7"],
+    outputNames: ["o0", "o1", "o2"],
+    testCases: [
+      tc({ i0: true, i1: false, i2: false, i3: false, i4: false, i5: false, i6: false, i7: false }, { o0: false, o1: false, o2: false }),
+      tc({ i0: false, i1: true, i2: false, i3: false, i4: false, i5: false, i6: false, i7: false }, { o0: true, o1: false, o2: false }),
+      tc({ i0: false, i1: false, i2: true, i3: false, i4: false, i5: false, i6: false, i7: false }, { o0: false, o1: true, o2: false }),
+      tc({ i0: false, i1: false, i2: false, i3: true, i4: false, i5: false, i6: false, i7: false }, { o0: true, o1: true, o2: false }),
+      tc({ i0: false, i1: false, i2: false, i3: false, i4: true, i5: false, i6: false, i7: false }, { o0: false, o1: false, o2: true }),
+      tc({ i0: false, i1: false, i2: false, i3: false, i4: false, i5: true, i6: false, i7: false }, { o0: true, o1: false, o2: true }),
+      tc({ i0: false, i1: false, i2: false, i3: false, i4: false, i5: false, i6: true, i7: false }, { o0: false, o1: true, o2: true }),
+      tc({ i0: false, i1: false, i2: false, i3: false, i4: false, i5: false, i6: false, i7: true }, { o0: true, o1: true, o2: true }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${ADD}${DEC}`,
+    fixedCode: `VAR i0 BITIN\nVAR i1 BITIN\nVAR i2 BITIN\nVAR i3 BITIN\nVAR i4 BITIN\nVAR i5 BITIN\nVAR i6 BITIN\nVAR i7 BITIN\nVAR o0 BITOUT\nVAR o1 BITOUT\nVAR o2 BITOUT`,
+    editableCode: `VAR or00 OR
+WIRE i1 _ TO or00 i0
+WIRE i3 _ TO or00 i1
+VAR or01 OR
+WIRE i5 _ TO or01 i0
+WIRE i7 _ TO or01 i1
+VAR or02 OR
+WIRE or00 _ TO or02 i0
+WIRE or01 _ TO or02 i1
+WIRE or02 _ TO o0 _
+VAR or10 OR
+WIRE i2 _ TO or10 i0
+WIRE i3 _ TO or10 i1
+VAR or11 OR
+WIRE i6 _ TO or11 i0
+WIRE i7 _ TO or11 i1
+VAR or12 OR
+WIRE or10 _ TO or12 i0
+WIRE or11 _ TO or12 i1
+WIRE or12 _ TO o1 _
+VAR or20 OR
+WIRE i4 _ TO or20 i0
+WIRE i5 _ TO or20 i1
+VAR or21 OR
+WIRE i6 _ TO or21 i0
+WIRE i7 _ TO or21 i1
+VAR or22 OR
+WIRE or20 _ TO or22 i0
+WIRE or21 _ TO or22 i1
+WIRE or22 _ TO o2 _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC"],
+    helpSections: ["circuit-decoder", "circuit-encoder"],
+  },
+  {
+    id: 16,
+    title: "Lv16: Byte Add",
+    description:
+      "いよいよ整数の足し算です！\n\n" +
+      "BYTEINは0〜255の整数を受け取り、8本のビット線（o0〜o7）に分解して出力します。" +
+      "BYTEOUTはその逆で、8本のビット線（i0〜i7）から整数を組み立てます。\n\n" +
+      "Full Adder（ADD）を8個連結して「リップルキャリー加算器」を構築しましょう。" +
+      "各ADDは対応するビット同士を足し、繰り上がり（carry）を次のビットのADDに渡します。\n\n" +
+      "  add0: a.o0 + b.o0         → out.i0（1の位）\n" +
+      "  add1: a.o1 + b.o1 + carry → out.i1（2の位）\n" +
+      "  add2: a.o2 + b.o2 + carry → out.i2（4の位）\n" +
+      "  ...以下同様\n\n" +
+      "結果が255を超える場合はオーバーフローし、下位8ビットのみが出力されます。",
+    inputNames: ["a", "b"],
+    outputNames: ["out"],
+    testCases: [
+      tc({ a: 0, b: 0 }, { out: 0 }),
+      tc({ a: 1, b: 0 }, { out: 1 }),
+      tc({ a: 0, b: 1 }, { out: 1 }),
+      tc({ a: 1, b: 1 }, { out: 2 }),
+      tc({ a: 42, b: 58 }, { out: 100 }),
+      tc({ a: 127, b: 128 }, { out: 255 }),
+      tc({ a: 200, b: 100 }, { out: 44 }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${ADD}${DEC}${ENC}`,
+    fixedCode: `VAR a BYTEIN\nVAR b BYTEIN\nVAR out BYTEOUT`,
+    editableCode: `VAR add0 ADD
+WIRE a o0 TO add0 i0
+WIRE b o0 TO add0 i1
+WIRE add0 o0 TO out i0
+VAR add1 ADD
+WIRE a o1 TO add1 i0
+WIRE b o1 TO add1 i1
+WIRE add0 o1 TO add1 i2
+WIRE add1 o0 TO out i1
+VAR add2 ADD
+WIRE a o2 TO add2 i0
+WIRE b o2 TO add2 i1
+WIRE add1 o1 TO add2 i2
+WIRE add2 o0 TO out i2
+VAR add3 ADD
+WIRE a o3 TO add3 i0
+WIRE b o3 TO add3 i1
+WIRE add2 o1 TO add3 i2
+WIRE add3 o0 TO out i3
+VAR add4 ADD
+WIRE a o4 TO add4 i0
+WIRE b o4 TO add4 i1
+WIRE add3 o1 TO add4 i2
+WIRE add4 o0 TO out i4
+VAR add5 ADD
+WIRE a o5 TO add5 i0
+WIRE b o5 TO add5 i1
+WIRE add4 o1 TO add5 i2
+WIRE add5 o0 TO out i5
+VAR add6 ADD
+WIRE a o6 TO add6 i0
+WIRE b o6 TO add6 i1
+WIRE add5 o1 TO add6 i2
+WIRE add6 o0 TO out i6
+VAR add7 ADD
+WIRE a o7 TO add7 i0
+WIRE b o7 TO add7 i1
+WIRE add6 o1 TO add7 i2
+WIRE add7 o0 TO out i7
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC", "ENC"],
+    helpSections: ["circuit-full-adder", "mod-bytein", "mod-byteout"],
   },
 ];


### PR DESCRIPTION
## Summary
- **Lv12: Half Adder** - 1ビット加算（XOR=合計, AND=繰り上がり）。解説多め
- **Lv13: Full Adder** - 繰り上がり入力対応の全加算器。**ADD**モジュールとして定義
- **Lv14: Decoder** - 3ビット→8出力デコーダ。**DEC**モジュールとして定義
- **Lv15: Encoder** - 8入力→3ビットエンコーダ。**ENC**モジュールとして定義
- **Lv16: Byte Add** - BYTEIN/BYTEOUTを使った8ビット整数加算（リップルキャリー加算器）
- VMに**BYTEIN/BYTEOUT**組み込みモジュール追加（整数⇔8ビット変換）
- 回路図に専用ノード（8ポート＋数値表示）追加
- 信号型を`boolean`→`boolean | number`に拡張

## Test plan
- [x] 全80テスト通過（ADD, DEC, ENC, BYTEIN/BYTEOUT, BYTEADDのユニットテスト含む）
- [x] TypeScript型チェック通過
- [ ] 各レベルをブラウザで動作確認
- [ ] BYTEIN/BYTEOUTノードに数値が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)