### PR TITLE
Add memory puzzle levels Lv17-19: SR Latch, D Latch, Byte Memory

### DIFF
--- a/packages/language/src/code-fragments.test.ts
+++ b/packages/language/src/code-fragments.test.ts
@@ -6,6 +6,7 @@ import {
   BYTEADD,
   DEC,
   DECODER_3BIT,
+  DLATCH,
   ENC,
   NOR,
   NOT,
@@ -854,6 +855,33 @@ test("BYTEADD", () => {
   expect([...vm.run(new Map([["a", 127], ["b", 128]])).entries()]).toEqual([["out", 255]]);
   // Overflow: 200 + 100 = 300 → 300 - 256 = 44
   expect([...vm.run(new Map([["a", 200], ["b", 100]])).entries()]).toEqual([["out", 44]]);
+});
+
+test("DLATCH", () => {
+  const vm = new Vm();
+  vm.compile(`
+    ${DLATCH}
+    VAR d BITIN
+    VAR e BITIN
+    VAR q BITOUT
+
+    VAR dl DLATCH
+    WIRE d _ TO dl d
+    WIRE e _ TO dl e
+    WIRE dl _ TO q _
+  `);
+  // Initial: hold → q=0
+  expect([...vm.run(new Map([["d", false], ["e", false]])).entries()]).toEqual([["q", false]]);
+  // Write 1
+  expect([...vm.run(new Map([["d", true], ["e", true]])).entries()]).toEqual([["q", true]]);
+  // Hold → q still 1
+  expect([...vm.run(new Map([["d", false], ["e", false]])).entries()]).toEqual([["q", true]]);
+  // Write 0
+  expect([...vm.run(new Map([["d", false], ["e", true]])).entries()]).toEqual([["q", false]]);
+  // Input changes but enable off → q still 0
+  expect([...vm.run(new Map([["d", true], ["e", false]])).entries()]).toEqual([["q", false]]);
+  // Write 1 again
+  expect([...vm.run(new Map([["d", true], ["e", true]])).entries()]).toEqual([["q", true]]);
 });
 
 test("DECODER_3BIT", () => {

--- a/packages/language/src/code-fragments.ts
+++ b/packages/language/src/code-fragments.ts
@@ -345,6 +345,28 @@ MOD START BYTEADD
 MOD END
 `;
 
+export const DLATCH = `\
+MOD START DLATCH
+  ${NOT}
+  ${AND}
+  VAR d BITIN
+  VAR e BITIN
+  VAR not NOT
+  WIRE d _ TO not _
+  VAR and_s AND
+  WIRE d _ TO and_s i0
+  WIRE e _ TO and_s i1
+  VAR and_r AND
+  WIRE not _ TO and_r i0
+  WIRE e _ TO and_r i1
+  VAR ff FLIPFLOP
+  WIRE and_s _ TO ff s
+  WIRE and_r _ TO ff r
+  VAR q BITOUT
+  WIRE ff _ TO q _
+MOD END
+`;
+
 export const DECODER_3BIT = `\
 MOD START DECODER_3BIT
   ${NOT}

--- a/packages/viewer/src/components/HelpManual.tsx
+++ b/packages/viewer/src/components/HelpManual.tsx
@@ -556,6 +556,129 @@ VAR x NOT`}</pre>
       </>
     ),
   },
+  {
+    id: "mod-flipflop",
+    title: "FLIPFLOP: 記憶素子",
+    content: (
+      <>
+        <p>
+          状態を記憶できる唯一のプリミティブモジュールです。
+          Set信号で1を記憶し、Reset信号で0を記憶します。
+          どちらも0なら前の状態を保持します。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>s</code></td><td>入力</td><td>Set（1を記憶）</td></tr>
+            <tr><td><code>r</code></td><td>入力</td><td>Reset（0を記憶）</td></tr>
+            <tr><td><code>q</code> / <code>_</code></td><td>出力</td><td>記憶されている値</td></tr>
+          </tbody>
+        </table>
+        <p>動作表（テストは順番に実行され、状態が引き継がれます）:</p>
+        <table>
+          <thead>
+            <tr><th>s</th><th>r</th><th>q</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>0</td><td>0</td><td>保持</td></tr>
+            <tr><td>0</td><td>1</td><td>0</td></tr>
+            <tr><td>1</td><td>0</td><td>1</td></tr>
+            <tr><td>1</td><td>1</td><td>エラー</td></tr>
+          </tbody>
+        </table>
+        <p>出力ポートは1つなので、WIRE文では <code>_</code> で指定できます。</p>
+      </>
+    ),
+  },
+  {
+    id: "circuit-sr-latch",
+    title: "SR Latch: セット・リセットラッチ",
+    content: (
+      <>
+        <p>
+          FLIPFLOPを使った最も基本的な記憶回路です。
+          Set(s)で1をセットし、Reset(r)で0にリセットします。
+          両方0のときは前の値を保持します。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>s</code></td><td>入力</td><td>Set（1にする）</td></tr>
+            <tr><td><code>r</code></td><td>入力</td><td>Reset（0にする）</td></tr>
+            <tr><td><code>q</code></td><td>出力</td><td>記憶値</td></tr>
+          </tbody>
+        </table>
+        <details>
+          <summary>ヒント</summary>
+          <p>FLIPFLOPを1つ配置して、s, rの入力とqの出力をそのまま結線するだけです。</p>
+        </details>
+      </>
+    ),
+  },
+  {
+    id: "circuit-d-latch",
+    title: "D Latch: データラッチ（DLATCH）",
+    content: (
+      <>
+        <p>
+          1ビットのメモリです。Enable(e)が1のときにData(d)の値を記憶し、
+          e=0のときは前の値を保持します。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>d</code></td><td>入力</td><td>記憶したい値</td></tr>
+            <tr><td><code>e</code></td><td>入力</td><td>Enable（書き込み許可）</td></tr>
+            <tr><td><code>q</code> / <code>_</code></td><td>出力</td><td>記憶されている値</td></tr>
+          </tbody>
+        </table>
+        <details>
+          <summary>ヒント</summary>
+          <p>
+            FLIPFLOPのs,rをd,eから生成します:
+            s = d AND e（dが1かつeが1でセット）、
+            r = (NOT d) AND e（dが0かつeが1でリセット）。
+          </p>
+        </details>
+      </>
+    ),
+  },
+  {
+    id: "circuit-byte-memory",
+    title: "Byte Memory: バイトメモリ",
+    content: (
+      <>
+        <p>
+          DLATCHを8個並列に並べて、8ビット（1バイト）の値を記憶する回路です。
+          書き込み信号wは全ビットで共有します。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>d</code> (BYTEIN)</td><td>入力</td><td>記憶したい8ビット値</td></tr>
+            <tr><td><code>w</code> (BITIN)</td><td>入力</td><td>書き込み信号</td></tr>
+            <tr><td><code>q</code> (BYTEOUT)</td><td>出力</td><td>記憶されている8ビット値</td></tr>
+          </tbody>
+        </table>
+        <details>
+          <summary>ヒント</summary>
+          <p>
+            DLATCHを8個作り、各ビットの入力(d o0〜o7)をDLATCHのdに、
+            wをすべてのDLATCHのeに接続します。
+            各DLATCHの出力qをBYTEOUTの対応するビット(q i0〜i7)に繋ぎます。
+          </p>
+        </details>
+      </>
+    ),
+  },
 ];
 
 export function HelpManual({ onClose, highlightSections }: Props) {

--- a/packages/viewer/src/language.d.ts
+++ b/packages/viewer/src/language.d.ts
@@ -55,6 +55,7 @@ declare module "@nandlang-ts/language/code-fragments" {
   export const ADD: string;
   export const DEC: string;
   export const ENC: string;
+  export const DLATCH: string;
   export const BYTEADD: string;
   export const DECODER_3BIT: string;
 }

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -10,6 +10,7 @@ import {
   ADD,
   DEC,
   ENC,
+  DLATCH,
 } from "@nandlang-ts/language/code-fragments";
 
 export type PuzzleTestCase = {
@@ -600,5 +601,140 @@ WIRE add7 o0 TO out i7
 `,
     availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC", "ENC"],
     helpSections: ["circuit-full-adder", "mod-bytein", "mod-byteout"],
+  },
+  {
+    id: 17,
+    title: "Lv17: SR Latch",
+    description:
+      "ここからは「記憶」を持つ回路に挑戦します！\n\n" +
+      "これまでの回路はすべて組み合わせ回路（入力が決まれば出力が決まる）でしたが、" +
+      "FLIPFLOPは状態を記憶できる特別なモジュールです。\n\n" +
+      "FLIPFLOPには2つの入力と1つの出力があります:\n" +
+      "  s（Set）= 1にすると出力qが1になる\n" +
+      "  r（Reset）= 1にすると出力qが0になる\n" +
+      "  両方0なら、前の状態を保持する\n\n" +
+      "入力s, rをFLIPFLOPに接続し、出力qを取り出してください。\n" +
+      "テストは順番に実行され、前のテストの状態が次に引き継がれます。",
+    inputNames: ["s", "r"],
+    outputNames: ["q"],
+    testCases: [
+      tc({ s: false, r: false }, { q: false }),
+      tc({ s: true, r: false }, { q: true }),
+      tc({ s: false, r: false }, { q: true }),
+      tc({ s: false, r: true }, { q: false }),
+      tc({ s: false, r: false }, { q: false }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${ADD}${DEC}${ENC}`,
+    fixedCode: `VAR s BITIN\nVAR r BITIN\nVAR q BITOUT`,
+    editableCode: `VAR ff FLIPFLOP
+WIRE s _ TO ff s
+WIRE r _ TO ff r
+WIRE ff _ TO q _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC", "ENC", "FLIPFLOP"],
+    helpSections: ["mod-flipflop", "circuit-sr-latch"],
+  },
+  {
+    id: 18,
+    title: "Lv18: D Latch",
+    description:
+      "SR Latchでは「セット」と「リセット」を別々に制御しましたが、" +
+      "実際のメモリでは「この値を覚えて」という操作の方が自然です。\n\n" +
+      "D Latch（データラッチ）は1ビットのメモリです:\n" +
+      "  d（Data）= 記憶したい値（0または1）\n" +
+      "  e（Enable）= 1のとき書き込み、0のとき保持\n" +
+      "  q = 記憶されている値\n\n" +
+      "e=1のとき: d=1ならq=1、d=0ならq=0（dの値がそのまま記憶される）\n" +
+      "e=0のとき: dが変わってもqは前の値を保持する\n\n" +
+      "ヒント: FLIPFLOPのs,rをd,eから作るには？\n" +
+      "  s = d AND e（dが1かつeが1のときセット）\n" +
+      "  r = (NOT d) AND e（dが0かつeが1のときリセット）",
+    inputNames: ["d", "e"],
+    outputNames: ["q"],
+    testCases: [
+      tc({ d: false, e: false }, { q: false }),
+      tc({ d: true, e: true }, { q: true }),
+      tc({ d: false, e: false }, { q: true }),
+      tc({ d: false, e: true }, { q: false }),
+      tc({ d: true, e: false }, { q: false }),
+      tc({ d: true, e: true }, { q: true }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${ADD}${DEC}${ENC}`,
+    fixedCode: `VAR d BITIN\nVAR e BITIN\nVAR q BITOUT`,
+    editableCode: `VAR not NOT
+VAR and_s AND
+VAR and_r AND
+VAR ff FLIPFLOP
+WIRE d _ TO not _
+WIRE d _ TO and_s i0
+WIRE e _ TO and_s i1
+WIRE not _ TO and_r i0
+WIRE e _ TO and_r i1
+WIRE and_s _ TO ff s
+WIRE and_r _ TO ff r
+WIRE ff _ TO q _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC", "ENC", "FLIPFLOP"],
+    helpSections: ["mod-flipflop", "circuit-sr-latch", "circuit-d-latch"],
+  },
+  {
+    id: 19,
+    title: "Lv19: Byte Memory",
+    description:
+      "D Latchで1ビットの記憶ができました。これを8個並べれば、1バイト（0〜255）を記憶できます！\n\n" +
+      "入力:\n" +
+      "  d（BYTEIN）= 記憶したい8ビットの値\n" +
+      "  w（BITIN）= 1のとき書き込み、0のとき保持\n\n" +
+      "出力:\n" +
+      "  q（BYTEOUT）= 記憶されている8ビットの値\n\n" +
+      "D Latch（DLATCH）を8個使い、各ビットごとに同じ書き込み信号wを共有します。\n" +
+      "DLATCHのポート: d（データ入力）、e（イネーブル）、q（出力）",
+    inputNames: ["d", "w"],
+    outputNames: ["q"],
+    testCases: [
+      tc({ d: 0, w: false }, { q: 0 }),
+      tc({ d: 42, w: true }, { q: 42 }),
+      tc({ d: 0, w: false }, { q: 42 }),
+      tc({ d: 255, w: true }, { q: 255 }),
+      tc({ d: 100, w: false }, { q: 255 }),
+      tc({ d: 0, w: true }, { q: 0 }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${ADD}${DEC}${ENC}${DLATCH}`,
+    fixedCode: `VAR d BYTEIN\nVAR w BITIN\nVAR q BYTEOUT`,
+    editableCode: `VAR dl0 DLATCH
+WIRE d o0 TO dl0 d
+WIRE w _ TO dl0 e
+WIRE dl0 _ TO q i0
+VAR dl1 DLATCH
+WIRE d o1 TO dl1 d
+WIRE w _ TO dl1 e
+WIRE dl1 _ TO q i1
+VAR dl2 DLATCH
+WIRE d o2 TO dl2 d
+WIRE w _ TO dl2 e
+WIRE dl2 _ TO q i2
+VAR dl3 DLATCH
+WIRE d o3 TO dl3 d
+WIRE w _ TO dl3 e
+WIRE dl3 _ TO q i3
+VAR dl4 DLATCH
+WIRE d o4 TO dl4 d
+WIRE w _ TO dl4 e
+WIRE dl4 _ TO q i4
+VAR dl5 DLATCH
+WIRE d o5 TO dl5 d
+WIRE w _ TO dl5 e
+WIRE dl5 _ TO q i5
+VAR dl6 DLATCH
+WIRE d o6 TO dl6 d
+WIRE w _ TO dl6 e
+WIRE dl6 _ TO q i6
+VAR dl7 DLATCH
+WIRE d o7 TO dl7 d
+WIRE w _ TO dl7 e
+WIRE dl7 _ TO q i7
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH"],
+    helpSections: ["mod-flipflop", "circuit-d-latch", "circuit-byte-memory", "mod-bytein", "mod-byteout"],
   },
 ];


### PR DESCRIPTION
## Summary
- **Lv17 SR Latch**: FLIPFLOPプリミティブのチュートリアル。Set/Reset/Hold動作を学ぶ
- **Lv18 D Latch**: 1ビットメモリ。FLIPFLOP + AND + NOT で Data+Enable 制御を構築
- **Lv19 Byte Memory**: DLATCHを8個並列に使い、BYTEIN/BYTEOUTで8ビット値を記憶

DLATCHコードフラグメント、ヘルプマニュアル（FLIPFLOP/SR Latch/D Latch/Byte Memory）、ユニットテストも追加。

## Test plan
- [x] `npm test --workspace=packages/language` 全81テスト通過
- [x] ビューワーの型チェック (`tsc --noEmit -p tsconfig.app.json`) エラーなし
- [ ] ブラウザでLv17〜19の各レベルを開き、テストケースが全パスすることを確認
- [ ] ヘルプマニュアルに新セクション（FLIPFLOP/SR Latch/D Latch/Byte Memory）が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)