### PR TITLE
Sandbox にモジュールプリロード追加 & マニュアルのセクション分類

### DIFF
--- a/packages/viewer/src/components/CodeEditorPanel.tsx
+++ b/packages/viewer/src/components/CodeEditorPanel.tsx
@@ -9,9 +9,10 @@ type Props = {
   error: string | null;
   puzzle?: Puzzle;
   initialCode?: string;
+  availableModules?: string[];
 };
 
-export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode = "" }: Props) {
+export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode = "", availableModules }: Props) {
   const [code, setCode] = useState(puzzle?.editableCode ?? initialCode);
   const [showHelp, setShowHelp] = useState(false);
 
@@ -23,7 +24,8 @@ export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode
   const fullCode = puzzle
     ? `${puzzle.moduleDefs}${puzzle.fixedCode}\n${code}`
     : code;
-  const hasModules = puzzle?.availableModules && puzzle.availableModules.length > 0;
+  const moduleList = puzzle?.availableModules ?? availableModules;
+  const hasModules = moduleList && moduleList.length > 0;
 
   return (
     <div className="code-editor-panel">
@@ -45,7 +47,7 @@ export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode
             <div className="available-modules">
               <span className="available-modules-label">利用可能モジュール: </span>
               <span className="available-modules-list">
-                {puzzle.availableModules!.join(", ")}
+                {moduleList!.join(", ")}
               </span>
             </div>
           )}
@@ -53,16 +55,26 @@ export function CodeEditorPanel({ onCompile, onDirty, error, puzzle, initialCode
         </>
       )}
       {!puzzle && (
-        <div className="panel-header">
-          <h3>Sandbox</h3>
-          <button
-            className="help-btn"
-            onClick={() => setShowHelp(!showHelp)}
-            title="マニュアルを開く"
-          >
-            ?
-          </button>
-        </div>
+        <>
+          <div className="panel-header">
+            <h3>Sandbox</h3>
+            <button
+              className="help-btn"
+              onClick={() => setShowHelp(!showHelp)}
+              title="マニュアルを開く"
+            >
+              ?
+            </button>
+          </div>
+          {hasModules && (
+            <div className="available-modules">
+              <span className="available-modules-label">利用可能モジュール: </span>
+              <span className="available-modules-list">
+                {moduleList!.join(", ")}
+              </span>
+            </div>
+          )}
+        </>
       )}
       <textarea
         value={code}

--- a/packages/viewer/src/components/HelpManual.tsx
+++ b/packages/viewer/src/components/HelpManual.tsx
@@ -6,15 +6,25 @@ type Props = {
   highlightSections?: string[];
 };
 
+type SectionCategory = "language" | "module" | "circuit";
+
 type Section = {
   id: string;
   title: string;
+  category: SectionCategory;
   content: ReactNode;
+};
+
+const categoryLabels: Record<SectionCategory, string> = {
+  language: "言語",
+  module: "モジュール",
+  circuit: "回路解説",
 };
 
 const sections: Section[] = [
   {
     id: "syntax-var",
+    category: "language",
     title: "VAR: ノードを配置する",
     content: (
       <>
@@ -35,6 +45,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "syntax-wire",
+    category: "language",
     title: "WIRE: ノード同士を結線する",
     content: (
       <>
@@ -54,6 +65,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "syntax-comment",
+    category: "language",
     title: "コメント",
     content: (
       <>
@@ -66,6 +78,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "mod-bitin",
+    category: "module",
     title: "BITIN: 外部入力",
     content: (
       <>
@@ -87,6 +100,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "mod-bitout",
+    category: "module",
     title: "BITOUT: 外部出力",
     content: (
       <>
@@ -108,6 +122,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "mod-nand",
+    category: "module",
     title: "NAND: 基本ゲート",
     content: (
       <>
@@ -143,6 +158,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "gate-on",
+    category: "module",
     title: "ON: 常時1出力",
     content: (
       <>
@@ -173,6 +189,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "gate-not",
+    category: "module",
     title: "NOT: 反転",
     content: (
       <>
@@ -206,6 +223,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "gate-and",
+    category: "module",
     title: "AND: 論理積",
     content: (
       <>
@@ -241,6 +259,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "gate-or",
+    category: "module",
     title: "OR: 論理和",
     content: (
       <>
@@ -276,6 +295,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "gate-nor",
+    category: "module",
     title: "NOR: 否定論理和",
     content: (
       <>
@@ -311,6 +331,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "gate-xor",
+    category: "module",
     title: "XOR: 排他的論理和",
     content: (
       <>
@@ -346,6 +367,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "gate-xnor",
+    category: "module",
     title: "XNOR: 排他的否定論理和",
     content: (
       <>
@@ -381,6 +403,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "mod-bytein",
+    category: "module",
     title: "BYTEIN: バイト入力",
     content: (
       <>
@@ -405,6 +428,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "mod-byteout",
+    category: "module",
     title: "BYTEOUT: バイト出力",
     content: (
       <>
@@ -429,6 +453,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "circuit-half-adder",
+    category: "circuit",
     title: "Half Adder: 半加算器",
     content: (
       <>
@@ -467,7 +492,8 @@ VAR x NOT`}</pre>
   },
   {
     id: "circuit-full-adder",
-    title: "Full Adder: 全加算器（ADD）",
+    category: "module",
+    title: "ADD: 全加算器",
     content: (
       <>
         <p>
@@ -498,7 +524,8 @@ VAR x NOT`}</pre>
   },
   {
     id: "circuit-decoder",
-    title: "Decoder: デコーダ（DEC）",
+    category: "module",
+    title: "DEC: デコーダ",
     content: (
       <>
         <p>
@@ -528,7 +555,8 @@ VAR x NOT`}</pre>
   },
   {
     id: "circuit-encoder",
-    title: "Encoder: エンコーダ（ENC）",
+    category: "module",
+    title: "ENC: エンコーダ",
     content: (
       <>
         <p>
@@ -558,6 +586,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "mod-flipflop",
+    category: "module",
     title: "FLIPFLOP: 記憶素子",
     content: (
       <>
@@ -594,6 +623,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "circuit-sr-latch",
+    category: "circuit",
     title: "SR Latch: セット・リセットラッチ",
     content: (
       <>
@@ -621,7 +651,8 @@ VAR x NOT`}</pre>
   },
   {
     id: "circuit-d-latch",
-    title: "D Latch: データラッチ（DLATCH）",
+    category: "module",
+    title: "DLATCH: データラッチ",
     content: (
       <>
         <p>
@@ -651,6 +682,7 @@ VAR x NOT`}</pre>
   },
   {
     id: "circuit-byte-memory",
+    category: "module",
     title: "Byte Memory: バイトメモリ",
     content: (
       <>
@@ -767,18 +799,22 @@ export function HelpManual({ onClose, highlightSections }: Props) {
                 })}
               </div>
             )}
-            <div className="help-toc-group">
-              <div className="help-toc-group-label">全セクション</div>
-              {sections.map((sec) => (
-                <button
-                  key={sec.id}
-                  className={`help-toc-item ${highlightSet.has(sec.id) ? "help-toc-item-hint" : ""}`}
-                  onClick={() => setSelectedSection(sec.id)}
-                >
-                  {sec.title}
-                </button>
-              ))}
-            </div>
+            {(["language", "module", "circuit"] as SectionCategory[]).map((cat) => (
+              <div className="help-toc-group" key={cat}>
+                <div className="help-toc-group-label">{categoryLabels[cat]}</div>
+                {sections
+                  .filter((sec) => sec.category === cat)
+                  .map((sec) => (
+                    <button
+                      key={sec.id}
+                      className={`help-toc-item ${highlightSet.has(sec.id) ? "help-toc-item-hint" : ""}`}
+                      onClick={() => setSelectedSection(sec.id)}
+                    >
+                      {sec.title}
+                    </button>
+                  ))}
+              </div>
+            ))}
           </>
         )}
       </div>

--- a/packages/viewer/src/language.d.ts
+++ b/packages/viewer/src/language.d.ts
@@ -44,6 +44,7 @@ declare module "@nandlang-ts/language/parser/program" {
 }
 
 declare module "@nandlang-ts/language/code-fragments" {
+  export const ON: string;
   export const NOT: string;
   export const AND: string;
   export const AND3: string;

--- a/packages/viewer/src/pages/SandboxPage.tsx
+++ b/packages/viewer/src/pages/SandboxPage.tsx
@@ -5,7 +5,18 @@ import type { NodeChange, EdgeChange } from "@xyflow/react";
 import { CodeEditorPanel } from "../components/CodeEditorPanel";
 import { CircuitDiagramPanel } from "../components/CircuitDiagramPanel";
 import { useCircuit } from "../hooks/useCircuit";
+import {
+  ON, NOT, AND, AND3, OR, OR3, NOR, XOR, XNOR,
+  ADD, DEC, ENC, BYTEADD, DLATCH,
+} from "@nandlang-ts/language/code-fragments";
 import "./SandboxPage.css";
+
+const PRELOADED_MODULES = `${ON}${NOT}${AND}${AND3}${OR}${OR3}${NOR}${XOR}${XNOR}${ADD}${DEC}${ENC}${BYTEADD}${DLATCH}`;
+
+const AVAILABLE_MODULE_NAMES = [
+  "ON", "NOT", "AND", "AND3", "OR", "OR3", "NOR", "XOR", "XNOR",
+  "ADD", "DEC", "ENC", "BYTEADD", "DLATCH",
+];
 
 const DEFAULT_CODE = `VAR a BITIN
 VAR b BITIN
@@ -22,7 +33,7 @@ export function SandboxPage() {
 
   const handleCompile = useCallback(
     (code: string) => {
-      circuit.compile(code);
+      circuit.compile(`${PRELOADED_MODULES}${code}`);
       setFitViewTrigger((c) => c + 1);
     },
     [circuit],
@@ -52,6 +63,7 @@ export function SandboxPage() {
           onCompile={handleCompile}
           error={circuit.error}
           initialCode={DEFAULT_CODE}
+          availableModules={AVAILABLE_MODULE_NAMES}
         />
       </div>
       <CircuitDiagramPanel


### PR DESCRIPTION
## Summary
- Sandbox ページで標準ライブラリモジュール（ON, NOT, AND, OR, XOR 等14種）をプリロードし、パズルと同様にそのまま使えるように
- CodeEditorPanel に `availableModules` prop を追加し、Sandbox でもパズルと同じスタイルで利用可能モジュール一覧を表示
- マニュアルの目次を「言語」「モジュール」「回路解説」の3カテゴリにグループ分け
- モジュールセクションのタイトル表記を「モジュール名: 日本語名」形式に統一（ADD, DEC, ENC, DLATCH）

## Test plan
- [ ] Sandbox ページで NOT, AND, OR 等のモジュールを VAR で使えることを確認
- [ ] Sandbox の利用可能モジュール一覧がパズルと同じスタイルで表示されることを確認
- [ ] マニュアルの目次が「言語」「モジュール」「回路解説」の3グループに分かれていることを確認
- [ ] パズルページのマニュアル表示が壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)