### PR TITLE
BYTE信号ポートWIRE結線サポートとBYTESPLIT/BYTEMERGE追加

### DIFF
--- a/packages/language/src/code-fragments.test.ts
+++ b/packages/language/src/code-fragments.test.ts
@@ -795,19 +795,12 @@ test("ENC", () => {
   ]);
 });
 
-test("BYTEIN and BYTEOUT", () => {
+test("BYTEIN to BYTEOUT byte wire", () => {
   const vm = new Vm();
   vm.compile(`
     VAR a BYTEIN
     VAR out BYTEOUT
-    WIRE a o0 TO out i0
-    WIRE a o1 TO out i1
-    WIRE a o2 TO out i2
-    WIRE a o3 TO out i3
-    WIRE a o4 TO out i4
-    WIRE a o5 TO out i5
-    WIRE a o6 TO out i6
-    WIRE a o7 TO out i7
+    WIRE a _ TO out _
   `);
   expect([...vm.run(new Map([["a", 0]])).entries()]).toEqual([["out", 0]]);
   expect([...vm.run(new Map([["a", 1]])).entries()]).toEqual([["out", 1]]);
@@ -816,7 +809,32 @@ test("BYTEIN and BYTEOUT", () => {
   expect([...vm.run(new Map([["a", 128]])).entries()]).toEqual([["out", 128]]);
 });
 
-test("BYTEADD", () => {
+test("BYTESPLIT and BYTEMERGE", () => {
+  const vm = new Vm();
+  vm.compile(`
+    VAR a BYTEIN
+    VAR s BYTESPLIT
+    WIRE a _ TO s _
+    VAR m BYTEMERGE
+    WIRE s o0 TO m i0
+    WIRE s o1 TO m i1
+    WIRE s o2 TO m i2
+    WIRE s o3 TO m i3
+    WIRE s o4 TO m i4
+    WIRE s o5 TO m i5
+    WIRE s o6 TO m i6
+    WIRE s o7 TO m i7
+    VAR out BYTEOUT
+    WIRE m _ TO out _
+  `);
+  expect([...vm.run(new Map([["a", 0]])).entries()]).toEqual([["out", 0]]);
+  expect([...vm.run(new Map([["a", 1]])).entries()]).toEqual([["out", 1]]);
+  expect([...vm.run(new Map([["a", 42]])).entries()]).toEqual([["out", 42]]);
+  expect([...vm.run(new Map([["a", 255]])).entries()]).toEqual([["out", 255]]);
+  expect([...vm.run(new Map([["a", 128]])).entries()]).toEqual([["out", 128]]);
+});
+
+test("BYTEADD with byte wire", () => {
   const vm = new Vm();
   vm.compile(`
     ${BYTEADD}
@@ -824,30 +842,9 @@ test("BYTEADD", () => {
     VAR b BYTEIN
     VAR out BYTEOUT
     VAR add BYTEADD
-    WIRE a o0 TO add a0
-    WIRE a o1 TO add a1
-    WIRE a o2 TO add a2
-    WIRE a o3 TO add a3
-    WIRE a o4 TO add a4
-    WIRE a o5 TO add a5
-    WIRE a o6 TO add a6
-    WIRE a o7 TO add a7
-    WIRE b o0 TO add b0
-    WIRE b o1 TO add b1
-    WIRE b o2 TO add b2
-    WIRE b o3 TO add b3
-    WIRE b o4 TO add b4
-    WIRE b o5 TO add b5
-    WIRE b o6 TO add b6
-    WIRE b o7 TO add b7
-    WIRE add o0 TO out i0
-    WIRE add o1 TO out i1
-    WIRE add o2 TO out i2
-    WIRE add o3 TO out i3
-    WIRE add o4 TO out i4
-    WIRE add o5 TO out i5
-    WIRE add o6 TO out i6
-    WIRE add o7 TO out i7
+    WIRE a _ TO add a
+    WIRE b _ TO add b
+    WIRE add out TO out _
   `);
   expect([...vm.run(new Map([["a", 0], ["b", 0]])).entries()]).toEqual([["out", 0]]);
   expect([...vm.run(new Map([["a", 1], ["b", 1]])).entries()]).toEqual([["out", 2]]);
@@ -855,6 +852,42 @@ test("BYTEADD", () => {
   expect([...vm.run(new Map([["a", 127], ["b", 128]])).entries()]).toEqual([["out", 255]]);
   // Overflow: 200 + 100 = 300 → 300 - 256 = 44
   expect([...vm.run(new Map([["a", 200], ["b", 100]])).entries()]).toEqual([["out", 44]]);
+});
+
+test("BIT to BYTE type mismatch error", () => {
+  const vm = new Vm();
+  expect(() => vm.compile(`
+    VAR a BITIN
+    VAR out BYTEOUT
+    WIRE a _ TO out _
+  `)).toThrow("Type mismatch: cannot wire BIT source to BYTE destination out");
+});
+
+test("BYTE to BIT type mismatch error", () => {
+  const vm = new Vm();
+  expect(() => vm.compile(`
+    VAR a BYTEIN
+    VAR out BITOUT
+    WIRE a _ TO out _
+  `)).toThrow("Type mismatch: cannot wire BYTE source to BIT destination out");
+});
+
+test("BIT to BYTE port name type mismatch error", () => {
+  const vm = new Vm();
+  expect(() => vm.compile(`
+    VAR a BITIN
+    VAR s BYTESPLIT
+    WIRE a _ TO s byte
+  `)).toThrow("Type mismatch: cannot wire BIT source to BYTE port");
+});
+
+test("BYTE to BIT port name type mismatch error", () => {
+  const vm = new Vm();
+  expect(() => vm.compile(`
+    VAR m BYTEMERGE
+    VAR out BITOUT
+    WIRE m byte TO out _
+  `)).toThrow("Type mismatch: cannot wire BYTE source to BIT destination out");
 });
 
 test("DLATCH", () => {

--- a/packages/language/src/code-fragments.ts
+++ b/packages/language/src/code-fragments.ts
@@ -279,69 +279,54 @@ MOD END
 export const BYTEADD = `\
 MOD START BYTEADD
   ${ADD}
-  VAR a0 BITIN
-  VAR a1 BITIN
-  VAR a2 BITIN
-  VAR a3 BITIN
-  VAR a4 BITIN
-  VAR a5 BITIN
-  VAR a6 BITIN
-  VAR a7 BITIN
-  VAR b0 BITIN
-  VAR b1 BITIN
-  VAR b2 BITIN
-  VAR b3 BITIN
-  VAR b4 BITIN
-  VAR b5 BITIN
-  VAR b6 BITIN
-  VAR b7 BITIN
+  VAR a BYTEIN
+  VAR b BYTEIN
+  VAR sa BYTESPLIT
+  WIRE a _ TO sa _
+  VAR sb BYTESPLIT
+  WIRE b _ TO sb _
   VAR add0 ADD
-  WIRE a0 _ TO add0 i0
-  WIRE b0 _ TO add0 i1
+  WIRE sa o0 TO add0 i0
+  WIRE sb o0 TO add0 i1
   VAR add1 ADD
-  WIRE a1 _ TO add1 i0
-  WIRE b1 _ TO add1 i1
+  WIRE sa o1 TO add1 i0
+  WIRE sb o1 TO add1 i1
   WIRE add0 o1 TO add1 i2
   VAR add2 ADD
-  WIRE a2 _ TO add2 i0
-  WIRE b2 _ TO add2 i1
+  WIRE sa o2 TO add2 i0
+  WIRE sb o2 TO add2 i1
   WIRE add1 o1 TO add2 i2
   VAR add3 ADD
-  WIRE a3 _ TO add3 i0
-  WIRE b3 _ TO add3 i1
+  WIRE sa o3 TO add3 i0
+  WIRE sb o3 TO add3 i1
   WIRE add2 o1 TO add3 i2
   VAR add4 ADD
-  WIRE a4 _ TO add4 i0
-  WIRE b4 _ TO add4 i1
+  WIRE sa o4 TO add4 i0
+  WIRE sb o4 TO add4 i1
   WIRE add3 o1 TO add4 i2
   VAR add5 ADD
-  WIRE a5 _ TO add5 i0
-  WIRE b5 _ TO add5 i1
+  WIRE sa o5 TO add5 i0
+  WIRE sb o5 TO add5 i1
   WIRE add4 o1 TO add5 i2
   VAR add6 ADD
-  WIRE a6 _ TO add6 i0
-  WIRE b6 _ TO add6 i1
+  WIRE sa o6 TO add6 i0
+  WIRE sb o6 TO add6 i1
   WIRE add5 o1 TO add6 i2
   VAR add7 ADD
-  WIRE a7 _ TO add7 i0
-  WIRE b7 _ TO add7 i1
+  WIRE sa o7 TO add7 i0
+  WIRE sb o7 TO add7 i1
   WIRE add6 o1 TO add7 i2
-  VAR o0 BITOUT
-  VAR o1 BITOUT
-  VAR o2 BITOUT
-  VAR o3 BITOUT
-  VAR o4 BITOUT
-  VAR o5 BITOUT
-  VAR o6 BITOUT
-  VAR o7 BITOUT
-  WIRE add0 o0 TO o0 _
-  WIRE add1 o0 TO o1 _
-  WIRE add2 o0 TO o2 _
-  WIRE add3 o0 TO o3 _
-  WIRE add4 o0 TO o4 _
-  WIRE add5 o0 TO o5 _
-  WIRE add6 o0 TO o6 _
-  WIRE add7 o0 TO o7 _
+  VAR m BYTEMERGE
+  WIRE add0 o0 TO m i0
+  WIRE add1 o0 TO m i1
+  WIRE add2 o0 TO m i2
+  WIRE add3 o0 TO m i3
+  WIRE add4 o0 TO m i4
+  WIRE add5 o0 TO m i5
+  WIRE add6 o0 TO m i6
+  WIRE add7 o0 TO m i7
+  VAR out BYTEOUT
+  WIRE m _ TO out _
 MOD END
 `;
 

--- a/packages/language/src/internal-model/module.ts
+++ b/packages/language/src/internal-model/module.ts
@@ -48,11 +48,14 @@ export class ByteinModule implements Module {
   public readonly name = "BYTEIN";
 
   public createVariable(varName: string): Variable {
-    const outPorts = new Map<string, Reactive<boolean>>();
+    const bytePorts: Reactive<boolean>[] = [];
     for (let i = 0; i < 8; i++) {
-      outPorts.set(`o${i}`, reactive(false));
+      bytePorts.push(reactive(false));
     }
-    return new Variable(varName, new Map(), outPorts);
+    return new Variable(
+      varName, new Map(), new Map(), [],
+      new Map(), new Map([["byte", bytePorts]]),
+    );
   }
 }
 
@@ -60,11 +63,50 @@ export class ByteoutModule implements Module {
   public readonly name = "BYTEOUT";
 
   public createVariable(varName: string): Variable {
-    const inPorts = new Map<string, Reactive<boolean>>();
+    const bytePorts: Reactive<boolean>[] = [];
     for (let i = 0; i < 8; i++) {
-      inPorts.set(`i${i}`, reactive(false));
+      bytePorts.push(reactive(false));
     }
-    return new Variable(varName, inPorts, new Map());
+    return new Variable(
+      varName, new Map(), new Map(), [],
+      new Map([["byte", bytePorts]]), new Map(),
+    );
+  }
+}
+
+export class BytesplitModule implements Module {
+  public readonly name = "BYTESPLIT";
+
+  public createVariable(varName: string): Variable {
+    const byteIn: Reactive<boolean>[] = [];
+    const outPorts = new Map<string, Reactive<boolean>>();
+    for (let i = 0; i < 8; i++) {
+      const inBit = reactive(false);
+      byteIn.push(inBit);
+      outPorts.set(`o${i}`, reactive(() => inBit.value));
+    }
+    return new Variable(
+      varName, new Map(), outPorts, [],
+      new Map([["byte", byteIn]]), new Map(),
+    );
+  }
+}
+
+export class BytemergeModule implements Module {
+  public readonly name = "BYTEMERGE";
+
+  public createVariable(varName: string): Variable {
+    const inPorts = new Map<string, Reactive<boolean>>();
+    const byteOut: Reactive<boolean>[] = [];
+    for (let i = 0; i < 8; i++) {
+      const inBit = reactive(false);
+      inPorts.set(`i${i}`, inBit);
+      byteOut.push(reactive(() => inBit.value));
+    }
+    return new Variable(
+      varName, inPorts, new Map(), [],
+      new Map(), new Map([["byte", byteOut]]),
+    );
   }
 }
 
@@ -133,20 +175,12 @@ export const createModule = (
             invariant(port, "Can't find port i0 of BITIN");
             bitOuts.set(variable.name, port);
           } else if (module instanceof ByteinModule) {
-            const ports: Reactive<boolean>[] = [];
-            for (let i = 0; i < 8; i++) {
-              const port = variable.outPorts.get(`o${i}`);
-              invariant(port, `Can't find port o${i} of BYTEIN`);
-              ports.push(port);
-            }
+            const ports = variable.byteOutPorts.get("byte");
+            invariant(ports, `Can't find byte port of BYTEIN`);
             byteIns.set(variable.name, ports);
           } else if (module instanceof ByteoutModule) {
-            const ports: Reactive<boolean>[] = [];
-            for (let i = 0; i < 8; i++) {
-              const port = variable.inPorts.get(`i${i}`);
-              invariant(port, `Can't find port i${i} of BYTEOUT`);
-              ports.push(port);
-            }
+            const ports = variable.byteInPorts.get("byte");
+            invariant(ports, `Can't find byte port of BYTEOUT`);
             byteOuts.set(variable.name, ports);
           }
         } else if (statement.subtype.type === "wireStatement") {
@@ -162,50 +196,37 @@ export const createModule = (
             srcVar,
             `wire source variable not found: ${srcVariableName}`,
           );
-          if (srcPortName === "_" && srcVar.outPorts.size !== 1)
-            throw new Error(
-              `Can't determine src port name of variable:${srcVar.name}`,
-            );
-          const fixedSrcPortName =
-            srcPortName === "_"
-              ? srcVar.outPorts.entries().next().value?.[0]
-              : srcPortName;
-          invariant(fixedSrcPortName, `Can't find source port ${srcPortName}`);
-          const srcPort = srcVar.outPorts.get(fixedSrcPortName);
-          invariant(
-            srcPort,
-            `Unknown port name of variable:${fixedSrcPortName}`,
-          );
-
           const destVar = variables.find((v) => v.name === destVariableName);
           invariant(
             destVar,
             `wire destination variable not found: ${destVariableName}`,
           );
-          if (destPortName === "_" && destVar.inPorts.size !== 1)
-            throw new Error(
-              `Can't determine dest port name of variable:${destVar.name}`,
-            );
-          const fixedDestPortName =
-            destPortName === "_"
-              ? destVar.inPorts.entries().next().value?.[0]
-              : destPortName;
-          invariant(
-            fixedDestPortName,
-            `Can't find source port ${destPortName}`,
-          );
-          const destPort = destVar.inPorts.get(fixedDestPortName);
-          invariant(
-            destPort,
-            `Unknown port name of variable:${fixedDestPortName}`,
-          );
 
-          // TODO: Depends on the internal specifications of the reactively lib.
-          if (destPort["fn"] != null)
-            throw new Error(
-              `destination port ${fixedDestPortName} of ${destVar.name} already wired`,
-            );
-          destPort.set(() => srcPort.value);
+          // Resolve source port(s) - may be BIT (single) or BYTE (8-bit array)
+          const srcResolved = resolveSrcPort(srcVar, srcPortName);
+
+          if (srcResolved.type === "bit") {
+            // BIT wire: resolve destination as BIT
+            const destPort = resolveDestBitPort(destVar, destPortName);
+            // TODO: Depends on the internal specifications of the reactively lib.
+            if (destPort["fn"] != null)
+              throw new Error(
+                `destination port ${destPortName} of ${destVar.name} already wired`,
+              );
+            destPort.set(() => srcResolved.port.value);
+          } else {
+            // BYTE wire: resolve destination as BYTE
+            const destPorts = resolveDestBytePorts(destVar, destPortName);
+            for (let i = 0; i < 8; i++) {
+              // TODO: Depends on the internal specifications of the reactively lib.
+              if (destPorts[i]["fn"] != null)
+                throw new Error(
+                  `destination byte port bit ${i} of ${destVar.name} already wired`,
+                );
+              const srcBit = srcResolved.ports[i];
+              destPorts[i].set(() => srcBit.value);
+            }
+          }
         } else if (statement.subtype.type === "moduleStatement") {
           const Udm = createModule(statement.subtype, [...modules]);
           modules.push(new Udm());
@@ -218,3 +239,73 @@ export const createModule = (
   Object.defineProperty(C, "name", { value: moduleStatement.name });
   return C;
 };
+
+type BitPort = { type: "bit"; port: Reactive<boolean> };
+type BytePort = { type: "byte"; ports: Reactive<boolean>[] };
+
+function resolveSrcPort(
+  srcVar: Variable,
+  portName: string,
+): BitPort | BytePort {
+  if (portName !== "_") {
+    const bitPort = srcVar.outPorts.get(portName);
+    if (bitPort) return { type: "bit", port: bitPort };
+    const bytePorts = srcVar.byteOutPorts.get(portName);
+    if (bytePorts) return { type: "byte", ports: bytePorts };
+    throw new Error(`Unknown output port name: ${portName} of variable: ${srcVar.name}`);
+  }
+  // Wildcard "_": determine unambiguously
+  const bitCount = srcVar.outPorts.size;
+  const byteCount = srcVar.byteOutPorts.size;
+  if (bitCount === 1 && byteCount === 0) {
+    return { type: "bit", port: srcVar.outPorts.values().next().value! };
+  }
+  if (byteCount === 1 && bitCount === 0) {
+    return { type: "byte", ports: srcVar.byteOutPorts.values().next().value! };
+  }
+  throw new Error(`Can't determine src port name of variable: ${srcVar.name}`);
+}
+
+function resolveDestBitPort(
+  destVar: Variable,
+  portName: string,
+): Reactive<boolean> {
+  if (portName !== "_") {
+    const port = destVar.inPorts.get(portName);
+    if (port) return port;
+    // Check if the port name matches a byte port → type mismatch
+    if (destVar.byteInPorts.has(portName)) {
+      throw new Error(`Type mismatch: cannot wire BIT source to BYTE port "${portName}" of ${destVar.name}`);
+    }
+    throw new Error(`Unknown input port name: ${portName} of variable: ${destVar.name}`);
+  }
+  if (destVar.inPorts.size === 1 && destVar.byteInPorts.size === 0) {
+    return destVar.inPorts.values().next().value!;
+  }
+  if (destVar.inPorts.size === 0 && destVar.byteInPorts.size > 0) {
+    throw new Error(`Type mismatch: cannot wire BIT source to BYTE destination ${destVar.name} (use BYTEMERGE to convert)`);
+  }
+  throw new Error(`Can't determine dest port name of variable: ${destVar.name}`);
+}
+
+function resolveDestBytePorts(
+  destVar: Variable,
+  portName: string,
+): Reactive<boolean>[] {
+  if (portName !== "_") {
+    const bytePorts = destVar.byteInPorts.get(portName);
+    if (bytePorts) return bytePorts;
+    // Check if the port name matches a bit port → type mismatch
+    if (destVar.inPorts.has(portName)) {
+      throw new Error(`Type mismatch: cannot wire BYTE source to BIT port "${portName}" of ${destVar.name}`);
+    }
+    throw new Error(`Unknown byte input port name: ${portName} of variable: ${destVar.name}`);
+  }
+  if (destVar.byteInPorts.size === 1) {
+    return destVar.byteInPorts.values().next().value!;
+  }
+  if (destVar.byteInPorts.size === 0 && destVar.inPorts.size > 0) {
+    throw new Error(`Type mismatch: cannot wire BYTE source to BIT destination ${destVar.name} (use BYTESPLIT to convert)`);
+  }
+  throw new Error(`Can't determine byte dest port name of variable: ${destVar.name}`);
+}

--- a/packages/language/src/internal-model/program.ts
+++ b/packages/language/src/internal-model/program.ts
@@ -1,5 +1,5 @@
 import { Program as ProgramAst } from "../parser/ast";
-import { BitinModule, BitoutModule, ByteinModule, ByteoutModule, createModule, FlipflopModule, NandModule } from "./module";
+import { BitinModule, BitoutModule, ByteinModule, BytemergeModule, ByteoutModule, BytesplitModule, createModule, FlipflopModule, NandModule } from "./module";
 import { Variable } from "./variable";
 
 export class Program {
@@ -12,7 +12,7 @@ export class Program {
         name: "Program",
         definitionStatements: this.programAst.statements,
       },
-      [new NandModule(), new BitinModule(), new BitoutModule(), new ByteinModule(), new ByteoutModule(), new FlipflopModule()],
+      [new NandModule(), new BitinModule(), new BitoutModule(), new ByteinModule(), new ByteoutModule(), new BytesplitModule(), new BytemergeModule(), new FlipflopModule()],
     );
     this.variable = new ProgramModule().createVariable("PROGRAM");
   }

--- a/packages/language/src/performance.test.ts
+++ b/packages/language/src/performance.test.ts
@@ -21,38 +21,42 @@ const moduleDefs = `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${ADD}${DEC
 const lv19Code = `${moduleDefs}VAR d BYTEIN
 VAR w BITIN
 VAR q BYTEOUT
+VAR ds BYTESPLIT
+WIRE d _ TO ds _
+VAR qm BYTEMERGE
+WIRE qm _ TO q _
 VAR dl0 DLATCH
-WIRE d o0 TO dl0 d
+WIRE ds o0 TO dl0 d
 WIRE w _ TO dl0 e
-WIRE dl0 _ TO q i0
+WIRE dl0 _ TO qm i0
 VAR dl1 DLATCH
-WIRE d o1 TO dl1 d
+WIRE ds o1 TO dl1 d
 WIRE w _ TO dl1 e
-WIRE dl1 _ TO q i1
+WIRE dl1 _ TO qm i1
 VAR dl2 DLATCH
-WIRE d o2 TO dl2 d
+WIRE ds o2 TO dl2 d
 WIRE w _ TO dl2 e
-WIRE dl2 _ TO q i2
+WIRE dl2 _ TO qm i2
 VAR dl3 DLATCH
-WIRE d o3 TO dl3 d
+WIRE ds o3 TO dl3 d
 WIRE w _ TO dl3 e
-WIRE dl3 _ TO q i3
+WIRE dl3 _ TO qm i3
 VAR dl4 DLATCH
-WIRE d o4 TO dl4 d
+WIRE ds o4 TO dl4 d
 WIRE w _ TO dl4 e
-WIRE dl4 _ TO q i4
+WIRE dl4 _ TO qm i4
 VAR dl5 DLATCH
-WIRE d o5 TO dl5 d
+WIRE ds o5 TO dl5 d
 WIRE w _ TO dl5 e
-WIRE dl5 _ TO q i5
+WIRE dl5 _ TO qm i5
 VAR dl6 DLATCH
-WIRE d o6 TO dl6 d
+WIRE ds o6 TO dl6 d
 WIRE w _ TO dl6 e
-WIRE dl6 _ TO q i6
+WIRE dl6 _ TO qm i6
 VAR dl7 DLATCH
-WIRE d o7 TO dl7 d
+WIRE ds o7 TO dl7 d
 WIRE w _ TO dl7 e
-WIRE dl7 _ TO q i7
+WIRE dl7 _ TO qm i7
 `;
 
 describe("performance", () => {

--- a/packages/viewer/src/components/nodes/ByteinNode.tsx
+++ b/packages/viewer/src/components/nodes/ByteinNode.tsx
@@ -2,8 +2,6 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { NodeData } from "../../lib/astToGraph";
 import "./nodeStyles.css";
 
-const PORTS = ["o0", "o1", "o2", "o3", "o4", "o5", "o6", "o7"];
-
 export function ByteinNode({ data }: NodeProps & { data: NodeData }) {
   const value = typeof data.value === "number" ? data.value : 0;
   return (
@@ -11,19 +9,12 @@ export function ByteinNode({ data }: NodeProps & { data: NodeData }) {
       <div className="node-label">{data.label}</div>
       <div className="node-type">BYTEIN</div>
       <div className="byte-value-display">{value}</div>
-      <div className="byte-ports">
-        {PORTS.map((port, i) => (
-          <div key={port} className="byte-port-row byte-port-out">
-            <span className="port-label">{port}</span>
-            <Handle
-              type="source"
-              position={Position.Right}
-              id={port}
-              style={{ top: `${((i + 1) / (PORTS.length + 1)) * 100}%` }}
-            />
-          </div>
-        ))}
-      </div>
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="byte"
+        style={{ top: "50%", width: 10, height: 10, background: "#6366f1", border: "2px solid #4f46e5" }}
+      />
     </div>
   );
 }

--- a/packages/viewer/src/components/nodes/ByteoutNode.tsx
+++ b/packages/viewer/src/components/nodes/ByteoutNode.tsx
@@ -2,26 +2,17 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { NodeData } from "../../lib/astToGraph";
 import "./nodeStyles.css";
 
-const PORTS = ["i0", "i1", "i2", "i3", "i4", "i5", "i6", "i7"];
-
 export function ByteoutNode({ data }: NodeProps & { data: NodeData }) {
   const value = typeof data.value === "number" ? data.value : 0;
   return (
     <div className="circuit-node byteout-node">
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="byte"
+        style={{ top: "50%", width: 10, height: 10, background: "#6366f1", border: "2px solid #4f46e5" }}
+      />
       <div className="byte-value-display">{value}</div>
-      <div className="byte-ports">
-        {PORTS.map((port, i) => (
-          <div key={port} className="byte-port-row byte-port-in">
-            <Handle
-              type="target"
-              position={Position.Left}
-              id={port}
-              style={{ top: `${((i + 1) / (PORTS.length + 1)) * 100}%` }}
-            />
-            <span className="port-label">{port}</span>
-          </div>
-        ))}
-      </div>
       <div className="node-label">{data.label}</div>
       <div className="node-type">BYTEOUT</div>
     </div>

--- a/packages/viewer/src/components/nodes/ModuleNode.tsx
+++ b/packages/viewer/src/components/nodes/ModuleNode.tsx
@@ -5,34 +5,61 @@ import "./nodeStyles.css";
 export function ModuleNode({ data }: NodeProps & { data: NodeData }) {
   const inputs = data.inputs;
   const outputs = data.outputs;
-  const maxPorts = Math.max(inputs.length, outputs.length, 1);
+  const byteInputs = data.byteInputs ?? [];
+  const byteOutputs = data.byteOutputs ?? [];
+
+  // Single bus handle per byte port
+  const allInputHandles: { id: string; label: string; isByte: boolean }[] = [
+    ...inputs.map((p) => ({ id: p, label: p, isByte: false })),
+    ...byteInputs.map((name) => ({ id: name, label: name, isByte: true })),
+  ];
+  const allOutputHandles: { id: string; label: string; isByte: boolean }[] = [
+    ...outputs.map((p) => ({ id: p, label: p, isByte: false })),
+    ...byteOutputs.map((name) => ({ id: name, label: name, isByte: true })),
+  ];
+
+  const portLabels = [
+    ...inputs,
+    ...byteInputs,
+  ];
+  const outLabels = [
+    ...outputs,
+    ...byteOutputs,
+  ];
+  const maxPorts = Math.max(allInputHandles.length, allOutputHandles.length, 1);
 
   return (
     <div className="circuit-node module-node">
-      {inputs.map((port, i) => (
+      {allInputHandles.map((handle, i) => (
         <Handle
-          key={`in-${port}`}
+          key={`in-${handle.id}`}
           type="target"
           position={Position.Left}
-          id={port}
-          style={{ top: `${((i + 1) / (inputs.length + 1)) * 100}%` }}
+          id={handle.id}
+          style={{
+            top: `${((i + 1) / (allInputHandles.length + 1)) * 100}%`,
+            ...(handle.isByte ? { width: 10, height: 10, background: "#6366f1", border: "2px solid #4f46e5" } : {}),
+          }}
         />
       ))}
       <div className="node-label">{data.label}</div>
       <div className="node-type">{data.moduleName}</div>
       {maxPorts > 1 && (
         <div style={{ display: "flex", justifyContent: "space-between", fontSize: 9, color: "#aaa", marginTop: 4 }}>
-          <span>{inputs.join(", ")}</span>
-          <span>{outputs.join(", ")}</span>
+          <span>{portLabels.join(", ")}</span>
+          <span>{outLabels.join(", ")}</span>
         </div>
       )}
-      {outputs.map((port, i) => (
+      {allOutputHandles.map((handle, i) => (
         <Handle
-          key={`out-${port}`}
+          key={`out-${handle.id}`}
           type="source"
           position={Position.Right}
-          id={port}
-          style={{ top: `${((i + 1) / (outputs.length + 1)) * 100}%` }}
+          id={handle.id}
+          style={{
+            top: `${((i + 1) / (allOutputHandles.length + 1)) * 100}%`,
+            ...(handle.isByte ? { width: 10, height: 10, background: "#6366f1", border: "2px solid #4f46e5" } : {}),
+          }}
         />
       ))}
     </div>

--- a/packages/viewer/src/lib/astToGraph.ts
+++ b/packages/viewer/src/lib/astToGraph.ts
@@ -2,15 +2,17 @@ import type { Node, Edge } from "@xyflow/react";
 import type { Program, SubStatement } from "@nandlang-ts/language/parser/ast";
 import dagre from "dagre";
 
-type PortInfo = { inputs: string[]; outputs: string[] };
+type PortInfo = { inputs: string[]; outputs: string[]; byteInputs: string[]; byteOutputs: string[] };
 
 const BUILTIN_PORTS: Record<string, PortInfo> = {
-  NAND: { inputs: ["i0", "i1"], outputs: ["o0"] },
-  BITIN: { inputs: [], outputs: ["o0"] },
-  BITOUT: { inputs: ["i0"], outputs: [] },
-  BYTEIN: { inputs: [], outputs: ["o0", "o1", "o2", "o3", "o4", "o5", "o6", "o7"] },
-  BYTEOUT: { inputs: ["i0", "i1", "i2", "i3", "i4", "i5", "i6", "i7"], outputs: [] },
-  FLIPFLOP: { inputs: ["s", "r"], outputs: ["q"] },
+  NAND: { inputs: ["i0", "i1"], outputs: ["o0"], byteInputs: [], byteOutputs: [] },
+  BITIN: { inputs: [], outputs: ["o0"], byteInputs: [], byteOutputs: [] },
+  BITOUT: { inputs: ["i0"], outputs: [], byteInputs: [], byteOutputs: [] },
+  BYTEIN: { inputs: [], outputs: [], byteInputs: [], byteOutputs: ["byte"] },
+  BYTEOUT: { inputs: [], outputs: [], byteInputs: ["byte"], byteOutputs: [] },
+  BYTESPLIT: { inputs: [], outputs: ["o0", "o1", "o2", "o3", "o4", "o5", "o6", "o7"], byteInputs: ["byte"], byteOutputs: [] },
+  BYTEMERGE: { inputs: ["i0", "i1", "i2", "i3", "i4", "i5", "i6", "i7"], outputs: [], byteInputs: [], byteOutputs: ["byte"] },
+  FLIPFLOP: { inputs: ["s", "r"], outputs: ["q"], byteInputs: [], byteOutputs: [] },
 };
 
 function resolveModulePorts(
@@ -20,7 +22,7 @@ function resolveModulePorts(
   if (BUILTIN_PORTS[moduleName]) return BUILTIN_PORTS[moduleName];
   const info = moduleDefs.get(moduleName);
   if (info) return info;
-  return { inputs: [], outputs: [] };
+  return { inputs: [], outputs: [], byteInputs: [], byteOutputs: [] };
 }
 
 function collectModuleDefs(
@@ -31,22 +33,21 @@ function collectModuleDefs(
     if (st.type === "moduleStatement") {
       const inputs: string[] = [];
       const outputs: string[] = [];
+      const byteInputs: string[] = [];
+      const byteOutputs: string[] = [];
       for (const defSt of st.definitionStatements) {
-        if (
-          defSt.subtype.type === "varStatement" &&
-          defSt.subtype.moduleName === "BITIN"
-        ) {
-          inputs.push(defSt.subtype.variableName);
-        } else if (
-          defSt.subtype.type === "varStatement" &&
-          defSt.subtype.moduleName === "BITOUT"
-        ) {
-          outputs.push(defSt.subtype.variableName);
+        if (defSt.subtype.type === "varStatement") {
+          const mod = defSt.subtype.moduleName;
+          const name = defSt.subtype.variableName;
+          if (mod === "BITIN") inputs.push(name);
+          else if (mod === "BITOUT") outputs.push(name);
+          else if (mod === "BYTEIN") byteInputs.push(name);
+          else if (mod === "BYTEOUT") byteOutputs.push(name);
         } else if (defSt.subtype.type === "moduleStatement") {
           collectModuleDefs([defSt.subtype], moduleDefs);
         }
       }
-      moduleDefs.set(st.name, { inputs, outputs });
+      moduleDefs.set(st.name, { inputs, outputs, byteInputs, byteOutputs });
       // Recurse for nested module defs
       collectModuleDefs(
         st.definitionStatements.map((s) => s.subtype),
@@ -61,6 +62,8 @@ export type NodeData = {
   moduleName: string;
   inputs: string[];
   outputs: string[];
+  byteInputs: string[];
+  byteOutputs: string[];
   value?: boolean | number;
 };
 
@@ -114,6 +117,8 @@ export function astToGraph(ast: Program): {
         moduleName: st.moduleName,
         inputs: ports.inputs,
         outputs: ports.outputs,
+        byteInputs: ports.byteInputs,
+        byteOutputs: ports.byteOutputs,
       },
     });
   }
@@ -122,27 +127,46 @@ export function astToGraph(ast: Program): {
   for (const st of subStatements) {
     if (st.type !== "wireStatement") continue;
 
+    const srcPorts = varPorts.get(st.srcVariableName);
+    const destPorts = varPorts.get(st.destVariableName);
+
     let srcHandle = st.srcPortName;
     let destHandle = st.destPortName;
 
-    // Resolve "_" port
-    if (srcHandle === "_") {
-      const ports = varPorts.get(st.srcVariableName);
-      if (ports && ports.outputs.length === 1) srcHandle = ports.outputs[0];
-    }
-    if (destHandle === "_") {
-      const ports = varPorts.get(st.destVariableName);
-      if (ports && ports.inputs.length === 1) destHandle = ports.inputs[0];
-    }
+    // Determine if this is a byte wire
+    const isByteWire = isResolvedAsByteWire(srcHandle, srcPorts, destHandle, destPorts);
 
-    edges.push({
-      id: `${st.srcVariableName}.${srcHandle}-${st.destVariableName}.${destHandle}`,
-      source: st.srcVariableName,
-      sourceHandle: srcHandle,
-      target: st.destVariableName,
-      targetHandle: destHandle,
-      animated: true,
-    });
+    if (isByteWire) {
+      // Generate single bus edge for BYTE wire
+      const srcBusHandle = resolveByteSourceBusHandle(srcHandle, srcPorts);
+      const destBusHandle = resolveByteDestBusHandle(destHandle, destPorts);
+      edges.push({
+        id: `${st.srcVariableName}.${srcBusHandle}-${st.destVariableName}.${destBusHandle}`,
+        source: st.srcVariableName,
+        sourceHandle: srcBusHandle,
+        target: st.destVariableName,
+        targetHandle: destBusHandle,
+        animated: true,
+        style: { strokeWidth: 3, stroke: "#6366f1" },
+      });
+    } else {
+      // Resolve "_" port for BIT wire
+      if (srcHandle === "_") {
+        if (srcPorts && srcPorts.outputs.length === 1) srcHandle = srcPorts.outputs[0];
+      }
+      if (destHandle === "_") {
+        if (destPorts && destPorts.inputs.length === 1) destHandle = destPorts.inputs[0];
+      }
+
+      edges.push({
+        id: `${st.srcVariableName}.${srcHandle}-${st.destVariableName}.${destHandle}`,
+        source: st.srcVariableName,
+        sourceHandle: srcHandle,
+        target: st.destVariableName,
+        targetHandle: destHandle,
+        animated: true,
+      });
+    }
   }
 
   // Apply dagre layout
@@ -151,8 +175,14 @@ export function astToGraph(ast: Program): {
   g.setDefaultEdgeLabel(() => ({}));
 
   for (const node of nodes) {
-    const isByte = node.type === "byteinNode" || node.type === "byteoutNode";
-    g.setNode(node.id, { width: NODE_WIDTH, height: isByte ? 200 : NODE_HEIGHT });
+    const data = node.data as NodeData;
+    const maxHandles = Math.max(
+      data.inputs.length + data.byteInputs.length,
+      data.outputs.length + data.byteOutputs.length,
+      1,
+    );
+    const nodeHeight = Math.max(NODE_HEIGHT, maxHandles * 30);
+    g.setNode(node.id, { width: NODE_WIDTH, height: nodeHeight });
   }
   for (const edge of edges) {
     g.setEdge(edge.source, edge.target);
@@ -175,4 +205,37 @@ export function astToGraph(ast: Program): {
   }
 
   return { nodes, edges, inputNames, outputNames };
+}
+
+function isSrcByte(handle: string, ports: PortInfo | undefined): boolean {
+  if (!ports) return false;
+  if (handle !== "_") {
+    return ports.byteOutputs.includes(handle);
+  }
+  return ports.byteOutputs.length === 1 && ports.outputs.length === 0;
+}
+
+function isDestByte(handle: string, ports: PortInfo | undefined): boolean {
+  if (!ports) return false;
+  if (handle !== "_") {
+    return ports.byteInputs.includes(handle);
+  }
+  return ports.byteInputs.length === 1 && ports.inputs.length === 0;
+}
+
+function isResolvedAsByteWire(
+  srcHandle: string,
+  srcPorts: PortInfo | undefined,
+  destHandle: string,
+  destPorts: PortInfo | undefined,
+): boolean {
+  return isSrcByte(srcHandle, srcPorts) && isDestByte(destHandle, destPorts);
+}
+
+function resolveByteSourceBusHandle(handle: string, ports: PortInfo | undefined): string {
+  return handle === "_" ? ports?.byteOutputs[0] ?? handle : handle;
+}
+
+function resolveByteDestBusHandle(handle: string, ports: PortInfo | undefined): string {
+  return handle === "_" ? ports?.byteInputs[0] ?? handle : handle;
 }

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -537,13 +537,15 @@ WIRE or22 _ TO o2 _
     title: "Lv16: Byte Add",
     description:
       "いよいよ整数の足し算です！\n\n" +
-      "BYTEINは0〜255の整数を受け取り、8本のビット線（o0〜o7）に分解して出力します。" +
-      "BYTEOUTはその逆で、8本のビット線（i0〜i7）から整数を組み立てます。\n\n" +
+      "BYTEINは0〜255の整数をバイト信号として受け取ります。" +
+      "BYTEOUTはその逆で、バイト信号から整数を出力します。\n\n" +
+      "BYTESPLITはバイト信号を8本のビット線（o0〜o7）に分解します。" +
+      "BYTEMERGEはその逆で、8本のビット線（i0〜i7）をバイト信号にまとめます。\n\n" +
       "Full Adder（ADD）を8個連結して「リップルキャリー加算器」を構築しましょう。" +
       "各ADDは対応するビット同士を足し、繰り上がり（carry）を次のビットのADDに渡します。\n\n" +
-      "  add0: a.o0 + b.o0         → out.i0（1の位）\n" +
-      "  add1: a.o1 + b.o1 + carry → out.i1（2の位）\n" +
-      "  add2: a.o2 + b.o2 + carry → out.i2（4の位）\n" +
+      "  add0: sa.o0 + sb.o0         → m.i0（1の位）\n" +
+      "  add1: sa.o1 + sb.o1 + carry → m.i1（2の位）\n" +
+      "  add2: sa.o2 + sb.o2 + carry → m.i2（4の位）\n" +
       "  ...以下同様\n\n" +
       "結果が255を超える場合はオーバーフローし、下位8ビットのみが出力されます。",
     inputNames: ["a", "b"],
@@ -594,48 +596,48 @@ WIRE or22 _ TO o2 _
       tc({ a: 85, b: 170 }, { out: 255 }),  // 交換法則
     ],
     moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${ADD}${DEC}${ENC}`,
-    fixedCode: `VAR a BYTEIN\nVAR b BYTEIN\nVAR out BYTEOUT`,
+    fixedCode: `VAR a BYTEIN\nVAR b BYTEIN\nVAR out BYTEOUT\nVAR sa BYTESPLIT\nWIRE a _ TO sa _\nVAR sb BYTESPLIT\nWIRE b _ TO sb _\nVAR m BYTEMERGE\nWIRE m _ TO out _`,
     editableCode: `VAR add0 ADD
-WIRE a o0 TO add0 i0
-WIRE b o0 TO add0 i1
-WIRE add0 o0 TO out i0
+WIRE sa o0 TO add0 i0
+WIRE sb o0 TO add0 i1
+WIRE add0 o0 TO m i0
 VAR add1 ADD
-WIRE a o1 TO add1 i0
-WIRE b o1 TO add1 i1
+WIRE sa o1 TO add1 i0
+WIRE sb o1 TO add1 i1
 WIRE add0 o1 TO add1 i2
-WIRE add1 o0 TO out i1
+WIRE add1 o0 TO m i1
 VAR add2 ADD
-WIRE a o2 TO add2 i0
-WIRE b o2 TO add2 i1
+WIRE sa o2 TO add2 i0
+WIRE sb o2 TO add2 i1
 WIRE add1 o1 TO add2 i2
-WIRE add2 o0 TO out i2
+WIRE add2 o0 TO m i2
 VAR add3 ADD
-WIRE a o3 TO add3 i0
-WIRE b o3 TO add3 i1
+WIRE sa o3 TO add3 i0
+WIRE sb o3 TO add3 i1
 WIRE add2 o1 TO add3 i2
-WIRE add3 o0 TO out i3
+WIRE add3 o0 TO m i3
 VAR add4 ADD
-WIRE a o4 TO add4 i0
-WIRE b o4 TO add4 i1
+WIRE sa o4 TO add4 i0
+WIRE sb o4 TO add4 i1
 WIRE add3 o1 TO add4 i2
-WIRE add4 o0 TO out i4
+WIRE add4 o0 TO m i4
 VAR add5 ADD
-WIRE a o5 TO add5 i0
-WIRE b o5 TO add5 i1
+WIRE sa o5 TO add5 i0
+WIRE sb o5 TO add5 i1
 WIRE add4 o1 TO add5 i2
-WIRE add5 o0 TO out i5
+WIRE add5 o0 TO m i5
 VAR add6 ADD
-WIRE a o6 TO add6 i0
-WIRE b o6 TO add6 i1
+WIRE sa o6 TO add6 i0
+WIRE sb o6 TO add6 i1
 WIRE add5 o1 TO add6 i2
-WIRE add6 o0 TO out i6
+WIRE add6 o0 TO m i6
 VAR add7 ADD
-WIRE a o7 TO add7 i0
-WIRE b o7 TO add7 i1
+WIRE sa o7 TO add7 i0
+WIRE sb o7 TO add7 i1
 WIRE add6 o1 TO add7 i2
-WIRE add7 o0 TO out i7
+WIRE add7 o0 TO m i7
 `,
-    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC", "ENC"],
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC", "ENC", "BYTESPLIT", "BYTEMERGE"],
     helpSections: ["circuit-full-adder", "mod-bytein", "mod-byteout"],
   },
   {
@@ -783,7 +785,8 @@ WIRE ff _ TO q _
       "  w（BITIN）= 1のとき書き込み、0のとき保持\n\n" +
       "出力:\n" +
       "  q（BYTEOUT）= 記憶されている8ビットの値\n\n" +
-      "D Latch（DLATCH）を8個使い、各ビットごとに同じ書き込み信号wを共有します。\n" +
+      "BYTESPLITでバイト信号を8本のビット線に分解し、D Latch（DLATCH）を8個使って各ビットを記憶し、" +
+      "BYTEMERGEで8本のビット線をバイト信号に戻します。\n" +
       "DLATCHのポート: d（データ入力）、e（イネーブル）、q（出力）",
     inputNames: ["d", "w"],
     outputNames: ["q"],
@@ -837,41 +840,41 @@ WIRE ff _ TO q _
       tc({ d: 0, w: false }, { q: 64 }),
     ],
     moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${ADD}${DEC}${ENC}${DLATCH}`,
-    fixedCode: `VAR d BYTEIN\nVAR w BITIN\nVAR q BYTEOUT`,
+    fixedCode: `VAR d BYTEIN\nVAR w BITIN\nVAR q BYTEOUT\nVAR ds BYTESPLIT\nWIRE d _ TO ds _\nVAR qm BYTEMERGE\nWIRE qm _ TO q _`,
     editableCode: `VAR dl0 DLATCH
-WIRE d o0 TO dl0 d
+WIRE ds o0 TO dl0 d
 WIRE w _ TO dl0 e
-WIRE dl0 _ TO q i0
+WIRE dl0 _ TO qm i0
 VAR dl1 DLATCH
-WIRE d o1 TO dl1 d
+WIRE ds o1 TO dl1 d
 WIRE w _ TO dl1 e
-WIRE dl1 _ TO q i1
+WIRE dl1 _ TO qm i1
 VAR dl2 DLATCH
-WIRE d o2 TO dl2 d
+WIRE ds o2 TO dl2 d
 WIRE w _ TO dl2 e
-WIRE dl2 _ TO q i2
+WIRE dl2 _ TO qm i2
 VAR dl3 DLATCH
-WIRE d o3 TO dl3 d
+WIRE ds o3 TO dl3 d
 WIRE w _ TO dl3 e
-WIRE dl3 _ TO q i3
+WIRE dl3 _ TO qm i3
 VAR dl4 DLATCH
-WIRE d o4 TO dl4 d
+WIRE ds o4 TO dl4 d
 WIRE w _ TO dl4 e
-WIRE dl4 _ TO q i4
+WIRE dl4 _ TO qm i4
 VAR dl5 DLATCH
-WIRE d o5 TO dl5 d
+WIRE ds o5 TO dl5 d
 WIRE w _ TO dl5 e
-WIRE dl5 _ TO q i5
+WIRE dl5 _ TO qm i5
 VAR dl6 DLATCH
-WIRE d o6 TO dl6 d
+WIRE ds o6 TO dl6 d
 WIRE w _ TO dl6 e
-WIRE dl6 _ TO q i6
+WIRE dl6 _ TO qm i6
 VAR dl7 DLATCH
-WIRE d o7 TO dl7 d
+WIRE ds o7 TO dl7 d
 WIRE w _ TO dl7 e
-WIRE dl7 _ TO q i7
+WIRE dl7 _ TO qm i7
 `,
-    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH"],
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH", "BYTESPLIT", "BYTEMERGE"],
     helpSections: ["mod-flipflop", "circuit-d-latch", "circuit-byte-memory", "mod-bytein", "mod-byteout"],
   },
 ];


### PR DESCRIPTION
## Summary
- BYTEIN/BYTEOUTからBITポートを削除し、BYTEポート専用モジュールに変更
- BYTESPLIT（BYTE→8BIT変換）とBYTEMERGE（8BIT→BYTE変換）モジュールを新規追加
- WIREハンドラをBYTEポート対応に拡張し、BIT↔BYTE型不一致時のコンパイルエラーを追加
- ViewerにBYTEバスライン表示（太い紫色の単一エッジ）を実装
- パズル16(Byte Add)と19(Byte Memory)を新アーキテクチャに更新
- dagreレイアウトのノード高さをポート数に基づいて動的に計算するよう改善

## Test plan
- [ ] `cd packages/language && npm test` で全21テスト通過確認
- [ ] `cd packages/viewer && npm run build` でビルド成功確認
- [ ] ブラウザでBYTEIN/BYTEOUT/BYTESPLIT/BYTEMERGEを含む回路のバスライン表示を確認
- [ ] パズル16(Byte Add)・19(Byte Memory)が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)