### PR TITLE
REGISTERモジュールとパズルレベルを追加

### DIFF
--- a/packages/language/src/code-fragments.test.ts
+++ b/packages/language/src/code-fragments.test.ts
@@ -13,6 +13,7 @@ import {
   ON,
   OR,
   OR3,
+  REGISTER,
   XNOR,
   XOR,
 } from "./code-fragments";
@@ -915,6 +916,43 @@ test("DLATCH", () => {
   expect([...vm.run(new Map([["d", true], ["e", false]])).entries()]).toEqual([["q", false]]);
   // Write 1 again
   expect([...vm.run(new Map([["d", true], ["e", true]])).entries()]).toEqual([["q", true]]);
+});
+
+test("REGISTER", () => {
+  const vm = new Vm();
+  vm.compile(`
+    ${REGISTER}
+    VAR d BITIN
+    VAR clk BITIN
+    VAR q BITOUT
+
+    VAR reg REGISTER
+    WIRE d _ TO reg d
+    WIRE clk _ TO reg clk
+    WIRE reg _ TO q _
+  `);
+  // Initial: clk=0, d=0 → master captures 0, slave holds initial 0 → q=0
+  expect([...vm.run(new Map([["d", false], ["clk", false]])).entries()]).toEqual([["q", false]]);
+  // clk=0, d=1 → master captures 1, slave holds → q=0
+  expect([...vm.run(new Map([["d", true], ["clk", false]])).entries()]).toEqual([["q", false]]);
+  // Rising edge: clk=1 → master holds 1, slave captures master(1) → q=1
+  expect([...vm.run(new Map([["d", true], ["clk", true]])).entries()]).toEqual([["q", true]]);
+  // clk=1, d changes to 0 → master still holds 1, slave transparent → q=1
+  expect([...vm.run(new Map([["d", false], ["clk", true]])).entries()]).toEqual([["q", true]]);
+  // clk=0 → master captures d=0, slave holds 1 → q=1
+  expect([...vm.run(new Map([["d", false], ["clk", false]])).entries()]).toEqual([["q", true]]);
+  // Rising edge: clk=1 → master holds 0, slave captures master(0) → q=0
+  expect([...vm.run(new Map([["d", false], ["clk", true]])).entries()]).toEqual([["q", false]]);
+  // Hold at 0: clk=0, d=1 → master captures 1, slave holds 0 → q=0
+  expect([...vm.run(new Map([["d", true], ["clk", false]])).entries()]).toEqual([["q", false]]);
+  // Rising edge: clk=1 → master holds 1, slave captures master(1) → q=1
+  expect([...vm.run(new Map([["d", true], ["clk", true]])).entries()]).toEqual([["q", true]]);
+  // clk=0, d=0 → master captures 0, slave holds 1 → q=1
+  expect([...vm.run(new Map([["d", false], ["clk", false]])).entries()]).toEqual([["q", true]]);
+  // Rising edge with d=0: clk=1 → master holds 0, slave captures → q=0
+  expect([...vm.run(new Map([["d", false], ["clk", true]])).entries()]).toEqual([["q", false]]);
+  // Hold: clk=0 → q=0
+  expect([...vm.run(new Map([["d", false], ["clk", false]])).entries()]).toEqual([["q", false]]);
 });
 
 test("DECODER_3BIT", () => {

--- a/packages/language/src/code-fragments.ts
+++ b/packages/language/src/code-fragments.ts
@@ -352,6 +352,25 @@ MOD START DLATCH
 MOD END
 `;
 
+export const REGISTER = `\
+MOD START REGISTER
+  ${DLATCH}
+  ${NOT}
+  VAR d BITIN
+  VAR clk BITIN
+  VAR nclk NOT
+  WIRE clk _ TO nclk _
+  VAR master DLATCH
+  WIRE d _ TO master d
+  WIRE nclk _ TO master e
+  VAR slave DLATCH
+  WIRE master _ TO slave d
+  WIRE clk _ TO slave e
+  VAR q BITOUT
+  WIRE slave _ TO q _
+MOD END
+`;
+
 export const DECODER_3BIT = `\
 MOD START DECODER_3BIT
   ${NOT}

--- a/packages/viewer/src/components/HelpManual.tsx
+++ b/packages/viewer/src/components/HelpManual.tsx
@@ -759,6 +759,42 @@ VAR x NOT`}</pre>
     ),
   },
   {
+    id: "circuit-register",
+    category: "circuit",
+    title: "Register: Dフリップフロップ（エッジトリガ）",
+    content: (
+      <>
+        <p>
+          D Latchが「レベルトリガ」（enable=1の間ずっと透過）であるのに対し、
+          Registerは「エッジトリガ」（クロックの立ち上がりの瞬間だけデータを取り込む）です。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>d</code></td><td>入力</td><td>記憶したい値</td></tr>
+            <tr><td><code>clk</code></td><td>入力</td><td>クロック信号</td></tr>
+            <tr><td><code>q</code> / <code>_</code></td><td>出力</td><td>記憶されている値</td></tr>
+          </tbody>
+        </table>
+        <p>マスター・スレーブ構成:</p>
+        <ul>
+          <li>マスターDLATCH: d=入力, e=NOT clk（clk=0で取り込み）</li>
+          <li>スレーブDLATCH: d=マスター出力, e=clk（clk=1で出力）</li>
+        </ul>
+        <details>
+          <summary>ヒント</summary>
+          <p>
+            NOTでclkを反転してマスターのeに接続し、
+            clkをそのままスレーブのeに接続します。
+            マスターの出力をスレーブの入力dに繋げば完成です。
+          </p>
+        </details>
+      </>
+    ),
+  },
+  {
     id: "circuit-byte-memory",
     category: "module",
     title: "Byte Memory: バイトメモリ",

--- a/packages/viewer/src/language.d.ts
+++ b/packages/viewer/src/language.d.ts
@@ -57,6 +57,7 @@ declare module "@nandlang-ts/language/code-fragments" {
   export const DEC: string;
   export const ENC: string;
   export const DLATCH: string;
+  export const REGISTER: string;
   export const BYTEADD: string;
   export const DECODER_3BIT: string;
   export const MUX: string;

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -11,7 +11,6 @@ import {
   DEC,
   ENC,
   DLATCH,
-  REGISTER,
   MUX,
   DMUX,
 } from "@nandlang-ts/language/code-fragments";

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -11,6 +11,7 @@ import {
   DEC,
   ENC,
   DLATCH,
+  REGISTER,
   MUX,
   DMUX,
 } from "@nandlang-ts/language/code-fragments";
@@ -961,5 +962,77 @@ WIRE dl7 _ TO qm i7
 `,
     availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "MUX", "DMUX", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH", "BYTESPLIT", "BYTEMERGE"],
     helpSections: ["mod-flipflop", "circuit-d-latch", "circuit-byte-memory", "mod-bytein", "mod-byteout"],
+  },
+  {
+    id: 22,
+    title: "Lv22: Register",
+    description:
+      "D Latchはenable=1の間ずっと入力が出力に反映される「レベルトリガ」でした。\n" +
+      "しかし実際のCPUでは、クロック信号の立ち上がりの瞬間だけデータを取り込む「エッジトリガ」が必要です。\n\n" +
+      "Register（Dフリップフロップ）はエッジトリガの1ビットメモリです:\n" +
+      "  d（Data）= 記憶したい値\n" +
+      "  clk（Clock）= クロック信号\n" +
+      "  q = 記憶されている値\n\n" +
+      "動作:\n" +
+      "  clkが0→1に変化した瞬間（立ち上がりエッジ）のdの値を記憶\n" +
+      "  clk=1の間にdが変化しても出力は変わらない\n" +
+      "  clk=0の間は出力を保持\n\n" +
+      "ヒント: DLATCHを2つ使う「マスター・スレーブ」構成で実現できます。\n" +
+      "  マスター: d=入力d, e=NOT clk（clk=0で入力を取り込む）\n" +
+      "  スレーブ: d=マスター出力, e=clk（clk=1でマスターの値を出力）\n" +
+      "clkが0→1になると、マスターが値を保持し、スレーブがその値を出力します。",
+    inputNames: ["d", "clk"],
+    outputNames: ["q"],
+    testCases: [
+      // 初期状態: clk=0, d=0 → q=0
+      tc({ d: false, clk: false }, { q: false }),
+      // clk=0のままd=1 → masterが1を取り込むがslaveは保持 → q=0
+      tc({ d: true, clk: false }, { q: false }),
+      // 立ち上がりエッジ: clk=1 → masterが1を保持、slaveが出力 → q=1
+      tc({ d: true, clk: true }, { q: true }),
+      // clk=1のままd=0 → masterは保持中なので変化なし → q=1
+      tc({ d: false, clk: true }, { q: true }),
+      // clk=0 → masterがd=0を取り込む、slaveは保持 → q=1
+      tc({ d: false, clk: false }, { q: true }),
+      // 立ち上がりエッジ: clk=1 → masterが0を保持、slaveが出力 → q=0
+      tc({ d: false, clk: true }, { q: false }),
+      // clk=0, d=1 → masterが1を取り込む、slaveは保持 → q=0
+      tc({ d: true, clk: false }, { q: false }),
+      // 立ち上がりエッジ: clk=1 → q=1
+      tc({ d: true, clk: true }, { q: true }),
+      // clk=0に戻る → q=1保持
+      tc({ d: false, clk: false }, { q: true }),
+      // もう一度立ち上がりエッジ（d=0） → q=0
+      tc({ d: false, clk: true }, { q: false }),
+      // clk=0, d=1 → q=0保持
+      tc({ d: true, clk: false }, { q: false }),
+      tc({ d: true, clk: false }, { q: false }),
+      // 立ち上がりエッジ → q=1
+      tc({ d: true, clk: true }, { q: true }),
+      // clk=1のままd変化 → q=1のまま
+      tc({ d: false, clk: true }, { q: true }),
+      tc({ d: true, clk: true }, { q: true }),
+      // clk=0, d=0 → masterが0を取り込む
+      tc({ d: false, clk: false }, { q: true }),
+      // 立ち上がりエッジ → q=0
+      tc({ d: false, clk: true }, { q: false }),
+      // 保持確認
+      tc({ d: true, clk: false }, { q: false }),
+      tc({ d: false, clk: false }, { q: false }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${MUX}${DMUX}${ADD}${DEC}${ENC}${DLATCH}`,
+    fixedCode: `VAR d BITIN\nVAR clk BITIN\nVAR q BITOUT`,
+    editableCode: `VAR nclk NOT
+WIRE clk _ TO nclk _
+VAR master DLATCH
+WIRE d _ TO master d
+WIRE nclk _ TO master e
+VAR slave DLATCH
+WIRE master _ TO slave d
+WIRE clk _ TO slave e
+WIRE slave _ TO q _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "MUX", "DMUX", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH"],
+    helpSections: ["mod-flipflop", "circuit-d-latch", "circuit-register"],
   },
 ];


### PR DESCRIPTION
## Summary
- マスター・スレーブD-FF構成による`REGISTER`コードフラグメントを追加（エッジトリガ動作）
- Lv22: Register パズルを追加（D Latchとの違いを学べる19テストケース付き）
- ヘルプマニュアルに`circuit-register`セクションを追加

## Test plan
- [x] `REGISTER`のユニットテスト（11ステップのエッジトリガ動作検証）が全パス
- [x] 既存テスト91件すべてパス
- [x] viewer TypeScript型チェックパス
- [ ] ブラウザでLv22パズルが表示され、模範解答で全テストケースがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)