### PR TITLE
REGISTER→REGリネームとBYTEREGモジュール追加

### DIFF
--- a/packages/language/src/code-fragments.test.ts
+++ b/packages/language/src/code-fragments.test.ts
@@ -4,6 +4,7 @@ import {
   AND,
   AND3,
   BYTEADD,
+  BYTEREG,
   DEC,
   DECODER_3BIT,
   DLATCH,
@@ -13,7 +14,7 @@ import {
   ON,
   OR,
   OR3,
-  REGISTER,
+  REG,
   XNOR,
   XOR,
 } from "./code-fragments";
@@ -918,15 +919,15 @@ test("DLATCH", () => {
   expect([...vm.run(new Map([["d", true], ["e", true]])).entries()]).toEqual([["q", true]]);
 });
 
-test("REGISTER", () => {
+test("REG", () => {
   const vm = new Vm();
   vm.compile(`
-    ${REGISTER}
+    ${REG}
     VAR d BITIN
     VAR clk BITIN
     VAR q BITOUT
 
-    VAR reg REGISTER
+    VAR reg REG
     WIRE d _ TO reg d
     WIRE clk _ TO reg clk
     WIRE reg _ TO q _
@@ -953,6 +954,41 @@ test("REGISTER", () => {
   expect([...vm.run(new Map([["d", false], ["clk", true]])).entries()]).toEqual([["q", false]]);
   // Hold: clk=0 → q=0
   expect([...vm.run(new Map([["d", false], ["clk", false]])).entries()]).toEqual([["q", false]]);
+});
+
+test("BYTEREG", () => {
+  const vm = new Vm();
+  vm.compile(`
+    ${BYTEREG}
+    VAR d BYTEIN
+    VAR clk BITIN
+    VAR q BYTEOUT
+
+    VAR reg BYTEREG
+    WIRE d _ TO reg d
+    WIRE clk _ TO reg clk
+    WIRE reg q TO q _
+  `);
+  // Initial: clk=0 → q=0
+  expect([...vm.run(new Map<string, boolean | number>([["d", 0], ["clk", false]])).entries()]).toEqual([["q", 0]]);
+  // clk=0, d=42 → master captures, slave holds → q=0
+  expect([...vm.run(new Map<string, boolean | number>([["d", 42], ["clk", false]])).entries()]).toEqual([["q", 0]]);
+  // Rising edge: clk=1 → q=42
+  expect([...vm.run(new Map<string, boolean | number>([["d", 42], ["clk", true]])).entries()]).toEqual([["q", 42]]);
+  // clk=1, d changes → q stays 42
+  expect([...vm.run(new Map<string, boolean | number>([["d", 100], ["clk", true]])).entries()]).toEqual([["q", 42]]);
+  // clk=0 → master captures d=100, slave holds → q=42
+  expect([...vm.run(new Map<string, boolean | number>([["d", 100], ["clk", false]])).entries()]).toEqual([["q", 42]]);
+  // Rising edge → q=100
+  expect([...vm.run(new Map<string, boolean | number>([["d", 100], ["clk", true]])).entries()]).toEqual([["q", 100]]);
+  // clk=0, d=255 → q=100
+  expect([...vm.run(new Map<string, boolean | number>([["d", 255], ["clk", false]])).entries()]).toEqual([["q", 100]]);
+  // Rising edge → q=255
+  expect([...vm.run(new Map<string, boolean | number>([["d", 255], ["clk", true]])).entries()]).toEqual([["q", 255]]);
+  // clk=0, d=0 → q=255
+  expect([...vm.run(new Map<string, boolean | number>([["d", 0], ["clk", false]])).entries()]).toEqual([["q", 255]]);
+  // Rising edge → q=0
+  expect([...vm.run(new Map<string, boolean | number>([["d", 0], ["clk", true]])).entries()]).toEqual([["q", 0]]);
 });
 
 test("DECODER_3BIT", () => {

--- a/packages/language/src/code-fragments.ts
+++ b/packages/language/src/code-fragments.ts
@@ -352,8 +352,8 @@ MOD START DLATCH
 MOD END
 `;
 
-export const REGISTER = `\
-MOD START REGISTER
+export const REG = `\
+MOD START REG
   ${DLATCH}
   ${NOT}
   VAR d BITIN
@@ -368,6 +368,51 @@ MOD START REGISTER
   WIRE clk _ TO slave e
   VAR q BITOUT
   WIRE slave _ TO q _
+MOD END
+`;
+
+export const BYTEREG = `\
+MOD START BYTEREG
+  ${REG}
+  VAR d BYTEIN
+  VAR clk BITIN
+  VAR ds BYTESPLIT
+  WIRE d _ TO ds _
+  VAR r0 REG
+  WIRE ds o0 TO r0 d
+  WIRE clk _ TO r0 clk
+  VAR r1 REG
+  WIRE ds o1 TO r1 d
+  WIRE clk _ TO r1 clk
+  VAR r2 REG
+  WIRE ds o2 TO r2 d
+  WIRE clk _ TO r2 clk
+  VAR r3 REG
+  WIRE ds o3 TO r3 d
+  WIRE clk _ TO r3 clk
+  VAR r4 REG
+  WIRE ds o4 TO r4 d
+  WIRE clk _ TO r4 clk
+  VAR r5 REG
+  WIRE ds o5 TO r5 d
+  WIRE clk _ TO r5 clk
+  VAR r6 REG
+  WIRE ds o6 TO r6 d
+  WIRE clk _ TO r6 clk
+  VAR r7 REG
+  WIRE ds o7 TO r7 d
+  WIRE clk _ TO r7 clk
+  VAR qm BYTEMERGE
+  WIRE r0 _ TO qm i0
+  WIRE r1 _ TO qm i1
+  WIRE r2 _ TO qm i2
+  WIRE r3 _ TO qm i3
+  WIRE r4 _ TO qm i4
+  WIRE r5 _ TO qm i5
+  WIRE r6 _ TO qm i6
+  WIRE r7 _ TO qm i7
+  VAR q BYTEOUT
+  WIRE qm _ TO q _
 MOD END
 `;
 

--- a/packages/viewer/src/components/HelpManual.tsx
+++ b/packages/viewer/src/components/HelpManual.tsx
@@ -795,6 +795,38 @@ VAR x NOT`}</pre>
     ),
   },
   {
+    id: "circuit-byte-register",
+    category: "circuit",
+    title: "Byte Register: 8ビットレジスタ（エッジトリガ）",
+    content: (
+      <>
+        <p>
+          REGを8個並列に並べて、8ビット（1バイト）の値をエッジトリガで記憶する回路です。
+          クロック信号clkは全ビットで共有します。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>d</code> (BYTEIN)</td><td>入力</td><td>記憶したい8ビット値</td></tr>
+            <tr><td><code>clk</code> (BITIN)</td><td>入力</td><td>クロック信号</td></tr>
+            <tr><td><code>q</code> (BYTEOUT)</td><td>出力</td><td>記憶されている8ビット値</td></tr>
+          </tbody>
+        </table>
+        <details>
+          <summary>ヒント</summary>
+          <p>
+            Byte Memoryと同じ構造ですが、DLATCHの代わりにREGを使います。
+            BYTESPLITで分解した各ビットをREGのdに、
+            clkをすべてのREGのclkに接続し、
+            各REGの出力をBYTEMERGEで合成します。
+          </p>
+        </details>
+      </>
+    ),
+  },
+  {
     id: "circuit-byte-memory",
     category: "module",
     title: "Byte Memory: バイトメモリ",

--- a/packages/viewer/src/language.d.ts
+++ b/packages/viewer/src/language.d.ts
@@ -57,7 +57,8 @@ declare module "@nandlang-ts/language/code-fragments" {
   export const DEC: string;
   export const ENC: string;
   export const DLATCH: string;
-  export const REGISTER: string;
+  export const REG: string;
+  export const BYTEREG: string;
   export const BYTEADD: string;
   export const DECODER_3BIT: string;
   export const MUX: string;

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -11,6 +11,7 @@ import {
   DEC,
   ENC,
   DLATCH,
+  REG,
   MUX,
   DMUX,
 } from "@nandlang-ts/language/code-fragments";
@@ -1033,5 +1034,97 @@ WIRE slave _ TO q _
 `,
     availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "MUX", "DMUX", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH"],
     helpSections: ["mod-flipflop", "circuit-d-latch", "circuit-register"],
+  },
+  {
+    id: 23,
+    title: "Lv23: Byte Register",
+    description:
+      "Lv21のByte MemoryではDLATCH（レベルトリガ）を8個使いましたが、" +
+      "今回はREG（エッジトリガ）を8個使って8ビットレジスタを作ります。\n\n" +
+      "入力:\n" +
+      "  d（BYTEIN）= 記憶したい8ビットの値\n" +
+      "  clk（BITIN）= クロック信号\n\n" +
+      "出力:\n" +
+      "  q（BYTEOUT）= 記憶されている8ビットの値\n\n" +
+      "clkが0→1に変化した瞬間のdの値を記憶します。" +
+      "clk=1の間にdが変化しても出力は変わりません。\n\n" +
+      "BYTESPLITでバイト信号を8本のビット線に分解し、REGを8個使って各ビットを記憶し、" +
+      "BYTEMERGEで8本のビット線をバイト信号に戻します。\n" +
+      "REGのポート: d（データ入力）、clk（クロック）、q（出力）",
+    inputNames: ["d", "clk"],
+    outputNames: ["q"],
+    testCases: [
+      // 初期状態: clk=0 → q=0
+      tc({ d: 0, clk: false }, { q: 0 }),
+      // d=42でもclk=0なら書き込まない
+      tc({ d: 42, clk: false }, { q: 0 }),
+      // 立ち上がりエッジ → q=42
+      tc({ d: 42, clk: true }, { q: 42 }),
+      // clk=1のままd変化 → q=42のまま
+      tc({ d: 100, clk: true }, { q: 42 }),
+      tc({ d: 0, clk: true }, { q: 42 }),
+      // clk=0 → masterがd=0を取り込む、q=42保持
+      tc({ d: 0, clk: false }, { q: 42 }),
+      // 立ち上がりエッジ → q=0
+      tc({ d: 0, clk: true }, { q: 0 }),
+      // clk=0, d=255
+      tc({ d: 255, clk: false }, { q: 0 }),
+      // 立ち上がりエッジ → q=255
+      tc({ d: 255, clk: true }, { q: 255 }),
+      // clk=0, d=170 (10101010)
+      tc({ d: 170, clk: false }, { q: 255 }),
+      // 立ち上がりエッジ → q=170
+      tc({ d: 170, clk: true }, { q: 170 }),
+      // clk=0, d=85 (01010101)
+      tc({ d: 85, clk: false }, { q: 170 }),
+      // 立ち上がりエッジ → q=85
+      tc({ d: 85, clk: true }, { q: 85 }),
+      // clk=1のままd変化 → q=85のまま
+      tc({ d: 128, clk: true }, { q: 85 }),
+      // clk=0, d=128
+      tc({ d: 128, clk: false }, { q: 85 }),
+      // 立ち上がりエッジ → q=128
+      tc({ d: 128, clk: true }, { q: 128 }),
+      // 保持確認
+      tc({ d: 0, clk: false }, { q: 128 }),
+      tc({ d: 255, clk: false }, { q: 128 }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${MUX}${DMUX}${ADD}${DEC}${ENC}${DLATCH}${REG}`,
+    fixedCode: `VAR d BYTEIN\nVAR clk BITIN\nVAR q BYTEOUT\nVAR ds BYTESPLIT\nWIRE d _ TO ds _\nVAR qm BYTEMERGE\nWIRE qm _ TO q _`,
+    editableCode: `VAR r0 REG
+WIRE ds o0 TO r0 d
+WIRE clk _ TO r0 clk
+WIRE r0 _ TO qm i0
+VAR r1 REG
+WIRE ds o1 TO r1 d
+WIRE clk _ TO r1 clk
+WIRE r1 _ TO qm i1
+VAR r2 REG
+WIRE ds o2 TO r2 d
+WIRE clk _ TO r2 clk
+WIRE r2 _ TO qm i2
+VAR r3 REG
+WIRE ds o3 TO r3 d
+WIRE clk _ TO r3 clk
+WIRE r3 _ TO qm i3
+VAR r4 REG
+WIRE ds o4 TO r4 d
+WIRE clk _ TO r4 clk
+WIRE r4 _ TO qm i4
+VAR r5 REG
+WIRE ds o5 TO r5 d
+WIRE clk _ TO r5 clk
+WIRE r5 _ TO qm i5
+VAR r6 REG
+WIRE ds o6 TO r6 d
+WIRE clk _ TO r6 clk
+WIRE r6 _ TO qm i6
+VAR r7 REG
+WIRE ds o7 TO r7 d
+WIRE clk _ TO r7 clk
+WIRE r7 _ TO qm i7
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "MUX", "DMUX", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH", "REG", "BYTESPLIT", "BYTEMERGE"],
+    helpSections: ["mod-flipflop", "circuit-d-latch", "circuit-register", "circuit-byte-register", "mod-bytein", "mod-byteout"],
   },
 ];


### PR DESCRIPTION
## Summary
- `REGISTER` を `REG` にリネーム（短く統一）
- `BYTEREG` コードフラグメントを追加（REGを8個並列使用した8ビットエッジトリガレジスタ）
- Lv23: Byte Register パズルを追加（Byte Memoryのエッジトリガ版）
- ヘルプマニュアルに `circuit-byte-register` セクションを追加

## Test plan
- [x] `REG` のユニットテスト（リネーム後も全パス）
- [x] `BYTEREG` のユニットテスト（10ステップのエッジトリガ動作検証）
- [x] 全92テストパス
- [x] viewer TypeScript型チェックパス
- [ ] ブラウザでLv23パズルが表示され、模範解答で全テストケースがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)