### PR TITLE
COUNTER組み込みモジュールを追加

### DIFF
--- a/packages/language/src/code-fragments.test.ts
+++ b/packages/language/src/code-fragments.test.ts
@@ -991,6 +991,60 @@ test("BYTEREG", () => {
   expect([...vm.run(new Map<string, boolean | number>([["d", 0], ["clk", true]])).entries()]).toEqual([["q", 0]]);
 });
 
+test("COUNTER", () => {
+  const vm = new Vm();
+  vm.compile(`
+    VAR reset BITIN
+    VAR load BYTEIN
+    VAR inc BITIN
+    VAR count BYTEOUT
+
+    VAR ctr COUNTER
+    WIRE reset _ TO ctr reset
+    WIRE load _ TO ctr load
+    WIRE inc _ TO ctr inc
+    WIRE ctr count TO count _
+  `);
+  const run = (reset: boolean, load: number, inc: boolean) =>
+    [...vm.run(new Map<string, boolean | number>([["reset", reset], ["load", load], ["inc", inc]])).entries()];
+
+  // 初期状態: hold → 0
+  expect(run(false, 0, false)).toEqual([["count", 0]]);
+  // inc → 1
+  expect(run(false, 0, true)).toEqual([["count", 1]]);
+  // inc → 2
+  expect(run(false, 0, true)).toEqual([["count", 2]]);
+  // inc → 3
+  expect(run(false, 0, true)).toEqual([["count", 3]]);
+  // hold → 3
+  expect(run(false, 0, false)).toEqual([["count", 3]]);
+  expect(run(false, 0, false)).toEqual([["count", 3]]);
+  // load 100
+  expect(run(false, 100, false)).toEqual([["count", 100]]);
+  // hold → 100
+  expect(run(false, 0, false)).toEqual([["count", 100]]);
+  // inc → 101
+  expect(run(false, 0, true)).toEqual([["count", 101]]);
+  // load takes priority over inc
+  expect(run(false, 42, true)).toEqual([["count", 42]]);
+  // reset takes priority over load
+  expect(run(true, 200, false)).toEqual([["count", 0]]);
+  // reset takes priority over inc
+  expect(run(true, 0, true)).toEqual([["count", 0]]);
+  // inc from 0 → 1
+  expect(run(false, 0, true)).toEqual([["count", 1]]);
+  // load 255
+  expect(run(false, 255, false)).toEqual([["count", 255]]);
+  // inc → overflow → 0
+  expect(run(false, 0, true)).toEqual([["count", 0]]);
+  // inc → 1
+  expect(run(false, 0, true)).toEqual([["count", 1]]);
+  // reset → 0
+  expect(run(true, 0, false)).toEqual([["count", 0]]);
+  // hold → 0
+  expect(run(false, 0, false)).toEqual([["count", 0]]);
+});
+
 test("DECODER_3BIT", () => {
   const runner = getRunner(`
     ${DECODER_3BIT}

--- a/packages/language/src/code-fragments.ts
+++ b/packages/language/src/code-fragments.ts
@@ -532,3 +532,4 @@ MOD START DMUX
   WIRE and1 _ TO b _
 MOD END
 `;
+

--- a/packages/language/src/internal-model/module.ts
+++ b/packages/language/src/internal-model/module.ts
@@ -138,6 +138,62 @@ export class FlipflopModule implements Module {
   }
 }
 
+export class CounterModule implements Module {
+  public readonly name = "COUNTER";
+
+  public createVariable(varName: string): Variable {
+    const reset = reactive(false);
+    const inc = reactive(false);
+    const loadBits: Reactive<boolean>[] = [];
+    for (let i = 0; i < 8; i++) {
+      loadBits.push(reactive(false));
+    }
+
+    let state = 0;
+
+    const countBits: Reactive<boolean>[] = [];
+    for (let i = 0; i < 8; i++) {
+      countBits.push(reactive(false));
+    }
+
+    const variable = new Variable(
+      varName,
+      new Map([
+        ["reset", reset],
+        ["inc", inc],
+      ]),
+      new Map(),
+      [],
+      new Map([["load", loadBits]]),
+      new Map([["count", countBits]]),
+    );
+
+    variable.onBeforeRead = () => {
+      const r = reset.value;
+      const n = inc.value;
+      let loadVal = 0;
+      for (let j = 0; j < 8; j++) {
+        if (loadBits[j].value) loadVal |= (1 << j);
+      }
+
+      if (r) {
+        state = 0;
+      } else if (loadVal !== 0) {
+        state = loadVal;
+      } else if (n) {
+        state = (state + 1) & 0xFF;
+      }
+
+      for (let i = 0; i < 8; i++) {
+        const bit = ((state >> i) & 1) === 1;
+        countBits[i].set(() => bit);
+      }
+    };
+
+    return variable;
+  }
+}
+
 export const createModule = (
   moduleStatement: Extract<SubStatement, { type: "moduleStatement" }>,
   availableModules: Module[],

--- a/packages/language/src/internal-model/program.ts
+++ b/packages/language/src/internal-model/program.ts
@@ -1,5 +1,5 @@
 import { Program as ProgramAst } from "../parser/ast";
-import { BitinModule, BitoutModule, ByteinModule, BytemergeModule, ByteoutModule, BytesplitModule, createModule, FlipflopModule, NandModule } from "./module";
+import { BitinModule, BitoutModule, ByteinModule, BytemergeModule, ByteoutModule, BytesplitModule, CounterModule, createModule, FlipflopModule, NandModule } from "./module";
 import { Variable } from "./variable";
 
 export class Program {
@@ -12,7 +12,7 @@ export class Program {
         name: "Program",
         definitionStatements: this.programAst.statements,
       },
-      [new NandModule(), new BitinModule(), new BitoutModule(), new ByteinModule(), new ByteoutModule(), new BytesplitModule(), new BytemergeModule(), new FlipflopModule()],
+      [new NandModule(), new BitinModule(), new BitoutModule(), new ByteinModule(), new ByteoutModule(), new BytesplitModule(), new BytemergeModule(), new FlipflopModule(), new CounterModule()],
     );
     this.variable = new ProgramModule().createVariable("PROGRAM");
   }
@@ -31,6 +31,8 @@ export class Program {
         }
       }
     }
+
+    this.variable.invokeBeforeRead();
 
     const outputSignals = new Map<string, boolean | number>();
     for (const [name, port] of this.variable.outPorts.entries()) {

--- a/packages/language/src/internal-model/variable.ts
+++ b/packages/language/src/internal-model/variable.ts
@@ -2,6 +2,8 @@ import { Reactive } from "@reactively/core";
 import { Module } from "./module";
 
 export class Variable {
+  public onBeforeRead?: () => void;
+
   constructor(
     public readonly name: string,
     public readonly inPorts: Map<string, Reactive<boolean>>,
@@ -10,4 +12,11 @@ export class Variable {
     public readonly byteInPorts: Map<string, Reactive<boolean>[]> = new Map(),
     public readonly byteOutPorts: Map<string, Reactive<boolean>[]> = new Map(),
   ) {}
+
+  public invokeBeforeRead(): void {
+    for (const child of this.children) {
+      child.invokeBeforeRead();
+    }
+    this.onBeforeRead?.();
+  }
 }

--- a/packages/viewer/src/components/HelpManual.tsx
+++ b/packages/viewer/src/components/HelpManual.tsx
@@ -827,6 +827,43 @@ VAR x NOT`}</pre>
     ),
   },
   {
+    id: "mod-counter",
+    category: "module",
+    title: "COUNTER: 8ビットカウンタ",
+    content: (
+      <>
+        <p>
+          8ビットのカウンタモジュールです。FLIPFLOPと同様にVM組み込みの特別なモジュールで、
+          内部に状態を持ちます。
+        </p>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>型</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>reset</code></td><td>入力</td><td>BIT</td><td>1で0にリセット</td></tr>
+            <tr><td><code>load</code></td><td>入力</td><td>BYTE</td><td>非ゼロの値でロード</td></tr>
+            <tr><td><code>inc</code></td><td>入力</td><td>BIT</td><td>1でカウンタ+1</td></tr>
+            <tr><td><code>count</code></td><td>出力</td><td>BYTE</td><td>現在のカウンタ値</td></tr>
+          </tbody>
+        </table>
+        <p>優先度: reset &gt; load &gt; inc &gt; 保持</p>
+        <table>
+          <thead>
+            <tr><th>reset</th><th>load</th><th>inc</th><th>動作</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>1</td><td>x</td><td>x</td><td>0にリセット</td></tr>
+            <tr><td>0</td><td>非0</td><td>x</td><td>load値をロード</td></tr>
+            <tr><td>0</td><td>0</td><td>1</td><td>count + 1</td></tr>
+            <tr><td>0</td><td>0</td><td>0</td><td>保持</td></tr>
+          </tbody>
+        </table>
+        <p>255の次は0にオーバーフローします。</p>
+      </>
+    ),
+  },
+  {
     id: "circuit-byte-memory",
     category: "module",
     title: "Byte Memory: バイトメモリ",

--- a/packages/viewer/src/lib/astToGraph.ts
+++ b/packages/viewer/src/lib/astToGraph.ts
@@ -13,6 +13,7 @@ const BUILTIN_PORTS: Record<string, PortInfo> = {
   BYTESPLIT: { inputs: [], outputs: ["o0", "o1", "o2", "o3", "o4", "o5", "o6", "o7"], byteInputs: ["byte"], byteOutputs: [] },
   BYTEMERGE: { inputs: ["i0", "i1", "i2", "i3", "i4", "i5", "i6", "i7"], outputs: [], byteInputs: [], byteOutputs: ["byte"] },
   FLIPFLOP: { inputs: ["s", "r"], outputs: ["q"], byteInputs: [], byteOutputs: [] },
+  COUNTER: { inputs: ["reset", "inc"], outputs: [], byteInputs: ["load"], byteOutputs: ["count"] },
 };
 
 function resolveModulePorts(

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -1127,4 +1127,71 @@ WIRE r7 _ TO qm i7
     availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "MUX", "DMUX", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH", "REG", "BYTESPLIT", "BYTEMERGE"],
     helpSections: ["mod-flipflop", "circuit-d-latch", "circuit-register", "circuit-byte-register", "mod-bytein", "mod-byteout"],
   },
+  {
+    id: 24,
+    title: "Lv24: Counter",
+    description:
+      "COUNTERは8ビットのカウンタモジュールです。FLIPFLOPと同様にVM組み込みの特別なモジュールで、" +
+      "内部に状態を持ちます。\n\n" +
+      "入力:\n" +
+      "  reset（BIT）= 1でカウンタを0にリセット\n" +
+      "  load（BYTE）= 非ゼロの値を入れるとその値をロード\n" +
+      "  inc（BIT）= 1でカウンタを+1\n\n" +
+      "出力:\n" +
+      "  count（BYTE）= 現在のカウンタ値\n\n" +
+      "優先度: reset > load > inc > 保持\n" +
+      "（resetが最優先、次にload、次にinc、どれもなければ値を保持）\n\n" +
+      "COUNTERモジュールを1つ配置して、入力と出力を正しく結線してください。",
+    inputNames: ["reset", "load", "inc"],
+    outputNames: ["count"],
+    testCases: [
+      // 初期状態: hold → 0
+      tc({ reset: false, load: 0, inc: false }, { count: 0 }),
+      // 0からカウントアップ → 1, 2, 3, 4, 5, 6, 7, 8
+      tc({ reset: false, load: 0, inc: true }, { count: 1 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 2 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 3 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 4 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 5 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 6 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 7 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 8 }),
+      // hold → 8
+      tc({ reset: false, load: 0, inc: false }, { count: 8 }),
+      // さらにカウントアップ → 9, 10
+      tc({ reset: false, load: 0, inc: true }, { count: 9 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 10 }),
+      // reset → 0
+      tc({ reset: true, load: 0, inc: false }, { count: 0 }),
+      // load 250してからカウントアップ → オーバーフロー
+      tc({ reset: false, load: 250, inc: false }, { count: 250 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 251 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 252 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 253 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 254 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 255 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 0 }),
+      // オーバーフロー後もカウントアップ
+      tc({ reset: false, load: 0, inc: true }, { count: 1 }),
+      tc({ reset: false, load: 0, inc: true }, { count: 2 }),
+      // 優先度確認: load > inc
+      tc({ reset: false, load: 42, inc: true }, { count: 42 }),
+      // 優先度確認: reset > load
+      tc({ reset: true, load: 200, inc: false }, { count: 0 }),
+      // 優先度確認: reset > inc
+      tc({ reset: true, load: 0, inc: true }, { count: 0 }),
+      // hold
+      tc({ reset: false, load: 0, inc: false }, { count: 0 }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${MUX}${DMUX}${ADD}${DEC}${ENC}${DLATCH}${REG}`,
+    fixedCode: `VAR reset BITIN\nVAR load BYTEIN\nVAR inc BITIN\nVAR count BYTEOUT`,
+    editableCode: `VAR ctr COUNTER
+WIRE reset _ TO ctr reset
+WIRE load _ TO ctr load
+WIRE inc _ TO ctr inc
+WIRE ctr count TO count _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "MUX", "DMUX", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH", "REG", "COUNTER", "BYTESPLIT", "BYTEMERGE"],
+    helpSections: ["mod-counter", "mod-bytein", "mod-byteout"],
+  },
 ];


### PR DESCRIPTION
## Summary
- COUNTER組み込みモジュールを追加（reset/load/inc入力、count出力、優先度: reset > load > inc > 保持）
- Variable.onBeforeReadライフサイクルフックを追加（リアクティブキャッシュ問題の回避）
- Lv24 Counterパズルを追加（カウントアップ・オーバーフロー・優先度確認のテストケース）
- COUNTERのヘルプセクション（mod-counter）を追加
- astToGraphのBUILTIN_PORTSにCOUNTERを追加（グラフ結線表示の修正）

## Test plan
- [x] 既存テスト全93件パス
- [x] COUNTERユニットテスト（inc連続・reset・load・優先度・オーバーフロー）
- [x] TypeScript型チェックパス
- [ ] ブラウザでLv24パズルの結線表示・テスト実行を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)