### PR TITLE
RAM組み込みモジュール（RAM2/4/8/16）を追加

### DIFF
--- a/packages/language/src/internal-model/module.test.ts
+++ b/packages/language/src/internal-model/module.test.ts
@@ -5,6 +5,7 @@ import {
   createModule,
   FlipflopModule,
   NandModule,
+  RamModule,
 } from "./module";
 import { nand } from "./gate";
 
@@ -63,6 +64,110 @@ describe("FlipflopModule", () => {
     ffVar.inPorts.get("s")!.set(true);
     ffVar.inPorts.get("r")!.set(true);
     expect(() => ffVar.outPorts.get("q")!.value).toThrowError();
+  });
+});
+
+describe("RamModule", () => {
+  function setAddr(v: ReturnType<RamModule["createVariable"]>, bits: boolean[]) {
+    for (let i = 0; i < bits.length; i++) {
+      v.inPorts.get(`a${i}`)!.set(bits[i]);
+    }
+  }
+
+  function setData(v: ReturnType<RamModule["createVariable"]>, val: number) {
+    const ports = v.byteInPorts.get("data")!;
+    for (let i = 0; i < 8; i++) {
+      ports[i].set(() => ((val >> i) & 1) === 1);
+    }
+  }
+
+  function readOut(v: ReturnType<RamModule["createVariable"]>): number {
+    v.invokeBeforeRead();
+    const ports = v.byteOutPorts.get("out")!;
+    let val = 0;
+    for (let i = 0; i < 8; i++) {
+      if (ports[i].value) val |= (1 << i);
+    }
+    return val;
+  }
+
+  test("RAM2: initial value is 0", () => {
+    const mod = new RamModule(1);
+    const v = mod.createVariable("ram");
+    setAddr(v, [false]);
+    v.inPorts.get("we")!.set(false);
+    expect(readOut(v)).toBe(0);
+    setAddr(v, [true]);
+    expect(readOut(v)).toBe(0);
+  });
+
+  test("RAM2: write and read", () => {
+    const mod = new RamModule(1);
+    const v = mod.createVariable("ram");
+    // Write 42 to addr 0
+    setAddr(v, [false]);
+    setData(v, 42);
+    v.inPorts.get("we")!.set(true);
+    expect(readOut(v)).toBe(42);
+    // Read addr 0 without write
+    v.inPorts.get("we")!.set(false);
+    expect(readOut(v)).toBe(42);
+    // Write 99 to addr 1
+    setAddr(v, [true]);
+    setData(v, 99);
+    v.inPorts.get("we")!.set(true);
+    expect(readOut(v)).toBe(99);
+    // Read addr 0 still has 42
+    setAddr(v, [false]);
+    v.inPorts.get("we")!.set(false);
+    expect(readOut(v)).toBe(42);
+    // Read addr 1 still has 99
+    setAddr(v, [true]);
+    expect(readOut(v)).toBe(99);
+  });
+
+  test("RAM2: we=0 does not write", () => {
+    const mod = new RamModule(1);
+    const v = mod.createVariable("ram");
+    setAddr(v, [false]);
+    setData(v, 123);
+    v.inPorts.get("we")!.set(false);
+    expect(readOut(v)).toBe(0);
+  });
+
+  test("RAM4: multiple addresses are independent", () => {
+    const mod = new RamModule(2);
+    const v = mod.createVariable("ram");
+    // Write different values to all 4 addresses
+    for (let addr = 0; addr < 4; addr++) {
+      setAddr(v, [(addr & 1) === 1, (addr & 2) === 2]);
+      setData(v, (addr + 1) * 10);
+      v.inPorts.get("we")!.set(true);
+      readOut(v);
+    }
+    // Read back and verify
+    v.inPorts.get("we")!.set(false);
+    for (let addr = 0; addr < 4; addr++) {
+      setAddr(v, [(addr & 1) === 1, (addr & 2) === 2]);
+      expect(readOut(v)).toBe((addr + 1) * 10);
+    }
+  });
+
+  test("RAM16: write and read across addresses", () => {
+    const mod = new RamModule(4);
+    const v = mod.createVariable("ram");
+    // Write to addr 15
+    setAddr(v, [true, true, true, true]);
+    setData(v, 255);
+    v.inPorts.get("we")!.set(true);
+    expect(readOut(v)).toBe(255);
+    // Addr 0 is still 0
+    setAddr(v, [false, false, false, false]);
+    v.inPorts.get("we")!.set(false);
+    expect(readOut(v)).toBe(0);
+    // Addr 15 still has 255
+    setAddr(v, [true, true, true, true]);
+    expect(readOut(v)).toBe(255);
   });
 });
 

--- a/packages/language/src/internal-model/module.ts
+++ b/packages/language/src/internal-model/module.ts
@@ -194,6 +194,76 @@ export class CounterModule implements Module {
   }
 }
 
+export class RamModule implements Module {
+  public readonly name: string;
+  private readonly addressBits: number;
+
+  constructor(addressBits: number) {
+    this.addressBits = addressBits;
+    this.name = "RAM" + (1 << addressBits);
+  }
+
+  public createVariable(varName: string): Variable {
+    const addrPorts: Reactive<boolean>[] = [];
+    for (let i = 0; i < this.addressBits; i++) {
+      addrPorts.push(reactive(false));
+    }
+    const we = reactive(false);
+
+    const dataBits: Reactive<boolean>[] = [];
+    for (let i = 0; i < 8; i++) {
+      dataBits.push(reactive(false));
+    }
+
+    const outBits: Reactive<boolean>[] = [];
+    for (let i = 0; i < 8; i++) {
+      outBits.push(reactive(false));
+    }
+
+    const memory = new Uint8Array(1 << this.addressBits);
+
+    const inPorts = new Map<string, Reactive<boolean>>();
+    for (let i = 0; i < this.addressBits; i++) {
+      inPorts.set(`a${i}`, addrPorts[i]);
+    }
+    inPorts.set("we", we);
+
+    const variable = new Variable(
+      varName,
+      inPorts,
+      new Map(),
+      [],
+      new Map([["data", dataBits]]),
+      new Map([["out", outBits]]),
+    );
+
+    variable.onBeforeRead = () => {
+      let addr = 0;
+      for (let i = 0; i < this.addressBits; i++) {
+        if (addrPorts[i].value) addr |= (1 << i);
+      }
+
+      if (we.value) {
+        let dataVal = 0;
+        for (let j = 0; j < 8; j++) {
+          if (dataBits[j].value) dataVal |= (1 << j);
+        }
+        memory[addr] = dataVal;
+      }
+
+      const val = memory[addr];
+      for (let i = 0; i < 8; i++) {
+        const bit = ((val >> i) & 1) === 1;
+        outBits[i].set(() => bit);
+      }
+    };
+
+    variable.getMemoryDump = () => new Uint8Array(memory);
+
+    return variable;
+  }
+}
+
 export const createModule = (
   moduleStatement: Extract<SubStatement, { type: "moduleStatement" }>,
   availableModules: Module[],

--- a/packages/language/src/internal-model/program.ts
+++ b/packages/language/src/internal-model/program.ts
@@ -1,5 +1,5 @@
 import { Program as ProgramAst } from "../parser/ast";
-import { BitinModule, BitoutModule, ByteinModule, BytemergeModule, ByteoutModule, BytesplitModule, CounterModule, createModule, FlipflopModule, NandModule } from "./module";
+import { BitinModule, BitoutModule, ByteinModule, BytemergeModule, ByteoutModule, BytesplitModule, CounterModule, createModule, FlipflopModule, NandModule, RamModule } from "./module";
 import { Variable } from "./variable";
 
 export class Program {
@@ -12,7 +12,7 @@ export class Program {
         name: "Program",
         definitionStatements: this.programAst.statements,
       },
-      [new NandModule(), new BitinModule(), new BitoutModule(), new ByteinModule(), new ByteoutModule(), new BytesplitModule(), new BytemergeModule(), new FlipflopModule(), new CounterModule()],
+      [new NandModule(), new BitinModule(), new BitoutModule(), new ByteinModule(), new ByteoutModule(), new BytesplitModule(), new BytemergeModule(), new FlipflopModule(), new CounterModule(), new RamModule(1), new RamModule(2), new RamModule(3), new RamModule(4)],
     );
     this.variable = new ProgramModule().createVariable("PROGRAM");
   }
@@ -57,5 +57,15 @@ export class Program {
       }
     }
     return signals;
+  }
+
+  public getMemoryDumps(): Map<string, Uint8Array> {
+    const dumps = new Map<string, Uint8Array>();
+    for (const child of this.variable.children) {
+      if (child.getMemoryDump) {
+        dumps.set(child.name, child.getMemoryDump());
+      }
+    }
+    return dumps;
   }
 }

--- a/packages/language/src/internal-model/variable.ts
+++ b/packages/language/src/internal-model/variable.ts
@@ -3,6 +3,7 @@ import { Module } from "./module";
 
 export class Variable {
   public onBeforeRead?: () => void;
+  public getMemoryDump?: () => Uint8Array;
 
   constructor(
     public readonly name: string,

--- a/packages/language/src/vm.ts
+++ b/packages/language/src/vm.ts
@@ -23,4 +23,9 @@ export class Vm {
     if (this.program == null) throw new Error(`No program compiled`);
     return this.program.getAllSignals();
   }
+
+  public getMemoryDumps(): Map<string, Uint8Array> {
+    if (this.program == null) throw new Error(`No program compiled`);
+    return this.program.getMemoryDumps();
+  }
 }

--- a/packages/viewer/src/components/CircuitDiagramPanel.tsx
+++ b/packages/viewer/src/components/CircuitDiagramPanel.tsx
@@ -19,6 +19,7 @@ import { ByteoutNode } from "./nodes/ByteoutNode";
 import { NandNode } from "./nodes/NandNode";
 import { FlipflopNode } from "./nodes/FlipflopNode";
 import { ModuleNode } from "./nodes/ModuleNode";
+import { RamNode } from "./nodes/RamNode";
 import type { NodeData } from "../lib/astToGraph";
 
 const nodeTypes: NodeTypes = {
@@ -29,6 +30,7 @@ const nodeTypes: NodeTypes = {
   nandNode: NandNode,
   flipflopNode: FlipflopNode,
   moduleNode: ModuleNode,
+  ramNode: RamNode,
 };
 
 type Props = {

--- a/packages/viewer/src/components/HelpManual.tsx
+++ b/packages/viewer/src/components/HelpManual.tsx
@@ -864,6 +864,47 @@ VAR x NOT`}</pre>
     ),
   },
   {
+    id: "mod-ram",
+    category: "module",
+    title: "RAM: ランダムアクセスメモリ",
+    content: (
+      <>
+        <p>
+          アドレス指定で読み書きできるメモリモジュールです。
+          アドレスビット数の異なる4種類（RAM2/4/8/16）があります。
+          FLIPFLOPやCOUNTERと同様にVM組み込みの特別なモジュールです。
+        </p>
+        <table>
+          <thead>
+            <tr><th>モジュール</th><th>アドレスビット</th><th>アドレス数</th><th>データ幅</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>RAM2</td><td>1 (a0)</td><td>2</td><td>8bit</td></tr>
+            <tr><td>RAM4</td><td>2 (a0,a1)</td><td>4</td><td>8bit</td></tr>
+            <tr><td>RAM8</td><td>3 (a0,a1,a2)</td><td>8</td><td>8bit</td></tr>
+            <tr><td>RAM16</td><td>4 (a0,a1,a2,a3)</td><td>16</td><td>8bit</td></tr>
+          </tbody>
+        </table>
+        <table>
+          <thead>
+            <tr><th>ポート</th><th>方向</th><th>型</th><th>説明</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>a0</code>〜<code>aN</code></td><td>入力</td><td>BIT</td><td>アドレスビット</td></tr>
+            <tr><td><code>we</code></td><td>入力</td><td>BIT</td><td>Write Enable（1で書き込み）</td></tr>
+            <tr><td><code>data</code></td><td>入力</td><td>BYTE</td><td>書き込みデータ</td></tr>
+            <tr><td><code>out</code></td><td>出力</td><td>BYTE</td><td>読み出しデータ</td></tr>
+          </tbody>
+        </table>
+        <p>
+          動作: <code>we=1</code> のとき <code>data</code> の値を指定アドレスに書き込みます。
+          出力 <code>out</code> は常に指定アドレスの現在の値です。
+          初期値はすべて0です。
+        </p>
+      </>
+    ),
+  },
+  {
     id: "circuit-byte-memory",
     category: "module",
     title: "Byte Memory: バイトメモリ",

--- a/packages/viewer/src/components/nodes/RamNode.tsx
+++ b/packages/viewer/src/components/nodes/RamNode.tsx
@@ -1,0 +1,60 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import type { NodeData } from "../../lib/astToGraph";
+import "./nodeStyles.css";
+
+export function RamNode({ data }: NodeProps & { data: NodeData }) {
+  const inputs = data.inputs;
+  const byteInputs = data.byteInputs ?? [];
+  const byteOutputs = data.byteOutputs ?? [];
+  const dump = data.memoryDump;
+
+  // Determine grid size from module name (RAM2=2, RAM4=4, RAM8=8, RAM16=16)
+  const size = parseInt(data.moduleName.replace("RAM", ""), 10) || 2;
+  const cols = size <= 2 ? 2 : 4;
+  const placeholder = Array.from({ length: size }, () => 0);
+  const cells = dump ?? placeholder;
+
+  const allInputHandles: { id: string; isByte: boolean }[] = [
+    ...inputs.map((p) => ({ id: p, isByte: false })),
+    ...byteInputs.map((name) => ({ id: name, isByte: true })),
+  ];
+  const allOutputHandles: { id: string; isByte: boolean }[] = [
+    ...byteOutputs.map((name) => ({ id: name, isByte: true })),
+  ];
+
+  return (
+    <div className="circuit-node ram-node">
+      {allInputHandles.map((handle, i) => (
+        <Handle
+          key={`in-${handle.id}`}
+          type="target"
+          position={Position.Left}
+          id={handle.id}
+          style={{
+            top: `${((i + 1) / (allInputHandles.length + 1)) * 100}%`,
+            ...(handle.isByte ? { width: 10, height: 10, background: "#6366f1", border: "2px solid #4f46e5" } : {}),
+          }}
+        />
+      ))}
+      <div className="node-label">{data.label}</div>
+      <div className="node-type">{data.moduleName}</div>
+      <div className="ram-grid" style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}>
+        {cells.map((val, i) => (
+          <div key={i} className={`ram-cell ${val !== 0 ? "ram-cell-active" : ""}`}>{val}</div>
+        ))}
+      </div>
+      {allOutputHandles.map((handle, i) => (
+        <Handle
+          key={`out-${handle.id}`}
+          type="source"
+          position={Position.Right}
+          id={handle.id}
+          style={{
+            top: `${((i + 1) / (allOutputHandles.length + 1)) * 100}%`,
+            width: 10, height: 10, background: "#6366f1", border: "2px solid #4f46e5",
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/viewer/src/components/nodes/nodeStyles.css
+++ b/packages/viewer/src/components/nodes/nodeStyles.css
@@ -101,3 +101,30 @@
   font-size: 9px;
   color: #aaa;
 }
+
+.ram-node {
+  border-color: #f59e0b;
+}
+
+.ram-grid {
+  display: grid;
+  gap: 1px;
+  margin-top: 4px;
+  font-family: monospace;
+  font-size: 9px;
+}
+
+.ram-cell {
+  padding: 1px 2px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 2px;
+  text-align: center;
+  color: #555;
+  min-width: 24px;
+}
+
+.ram-cell-active {
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+  font-weight: bold;
+}

--- a/packages/viewer/src/hooks/useCircuit.ts
+++ b/packages/viewer/src/hooks/useCircuit.ts
@@ -46,6 +46,7 @@ export function useCircuit() {
 
       const outputs = vm.run(initialInputs);
       setOutputSignals(outputs);
+      const memoryDumps = vm.getMemoryDumps();
 
       // Update node data with output values
       const updatedNodes = graph.nodes.map((node) => {
@@ -60,6 +61,12 @@ export function useCircuit() {
         }
         if (node.data.moduleName === "BYTEIN") {
           return { ...node, data: { ...node.data, value: 0 } };
+        }
+        if (node.data.moduleName.startsWith("RAM")) {
+          const dump = memoryDumps.get(node.id);
+          if (dump) {
+            return { ...node, data: { ...node.data, memoryDump: Array.from(dump) } };
+          }
         }
         return node;
       });
@@ -81,6 +88,7 @@ export function useCircuit() {
           try {
             const outputs = vmRef.current.run(next);
             setOutputSignals(outputs);
+            const memoryDumps = vmRef.current.getMemoryDumps();
 
             setNodes((prevNodes) =>
               prevNodes.map((node) => {
@@ -108,6 +116,12 @@ export function useCircuit() {
                     data: { ...node.data, value: next.get(node.id) ?? 0 },
                   };
                 }
+                if (node.data.moduleName.startsWith("RAM")) {
+                  const dump = memoryDumps.get(node.id);
+                  if (dump) {
+                    return { ...node, data: { ...node.data, memoryDump: Array.from(dump) } };
+                  }
+                }
                 return node;
               }),
             );
@@ -127,6 +141,7 @@ export function useCircuit() {
       inputs: Map<string, boolean | number>,
       outputs: Map<string, boolean | number>,
       allSignals: Map<string, boolean>,
+      memoryDumps?: Map<string, Uint8Array>,
     ) => {
       setNodes((prevNodes) =>
         prevNodes.map((node) => {
@@ -158,6 +173,12 @@ export function useCircuit() {
             const q = allSignals.get(`${node.id}.q`);
             if (q !== undefined) {
               return { ...node, data: { ...node.data, value: q } };
+            }
+          }
+          if (node.data.moduleName.startsWith("RAM") && memoryDumps) {
+            const dump = memoryDumps.get(node.id);
+            if (dump) {
+              return { ...node, data: { ...node.data, memoryDump: Array.from(dump) } };
             }
           }
           return node;

--- a/packages/viewer/src/hooks/useCircuit.ts
+++ b/packages/viewer/src/hooks/useCircuit.ts
@@ -65,7 +65,7 @@ export function useCircuit() {
         if (node.data.moduleName.startsWith("RAM")) {
           const dump = memoryDumps.get(node.id);
           if (dump) {
-            return { ...node, data: { ...node.data, memoryDump: Array.from(dump) } };
+            return { ...node, data: { ...node.data, memoryDump: Array.from(dump) as number[] } };
           }
         }
         return node;
@@ -119,7 +119,7 @@ export function useCircuit() {
                 if (node.data.moduleName.startsWith("RAM")) {
                   const dump = memoryDumps.get(node.id);
                   if (dump) {
-                    return { ...node, data: { ...node.data, memoryDump: Array.from(dump) } };
+                    return { ...node, data: { ...node.data, memoryDump: Array.from(dump) as number[] } };
                   }
                 }
                 return node;
@@ -178,7 +178,7 @@ export function useCircuit() {
           if (node.data.moduleName.startsWith("RAM") && memoryDumps) {
             const dump = memoryDumps.get(node.id);
             if (dump) {
-              return { ...node, data: { ...node.data, memoryDump: Array.from(dump) } };
+              return { ...node, data: { ...node.data, memoryDump: Array.from(dump) as number[] } };
             }
           }
           return node;

--- a/packages/viewer/src/hooks/useTestCases.ts
+++ b/packages/viewer/src/hooks/useTestCases.ts
@@ -13,6 +13,7 @@ type OnTestRun = (
   inputs: Map<string, boolean | number>,
   outputs: Map<string, boolean | number>,
   allSignals: Map<string, boolean>,
+  memoryDumps: Map<string, Uint8Array>,
 ) => void;
 
 export function useTestCases(code: string | null, onTestRun?: OnTestRun) {
@@ -84,7 +85,7 @@ export function useTestCases(code: string | null, onTestRun?: OnTestRun) {
       return result;
     });
 
-    onTestRunRef.current?.(tc.inputs, actualOutputs, vm.getAllSignals());
+    onTestRunRef.current?.(tc.inputs, actualOutputs, vm.getAllSignals(), vm.getMemoryDumps());
 
     if (pass && idx + 1 < testCasesRef.current.length) {
       indexRef.current = idx + 1;

--- a/packages/viewer/src/language.d.ts
+++ b/packages/viewer/src/language.d.ts
@@ -3,6 +3,7 @@ declare module "@nandlang-ts/language/vm" {
     compile(programString: string): void;
     run(inputSignals: Map<string, boolean | number>): Map<string, boolean | number>;
     getAllSignals(): Map<string, boolean>;
+    getMemoryDumps(): Map<string, Uint8Array>;
   }
 }
 

--- a/packages/viewer/src/lib/astToGraph.ts
+++ b/packages/viewer/src/lib/astToGraph.ts
@@ -14,6 +14,10 @@ const BUILTIN_PORTS: Record<string, PortInfo> = {
   BYTEMERGE: { inputs: ["i0", "i1", "i2", "i3", "i4", "i5", "i6", "i7"], outputs: [], byteInputs: [], byteOutputs: ["byte"] },
   FLIPFLOP: { inputs: ["s", "r"], outputs: ["q"], byteInputs: [], byteOutputs: [] },
   COUNTER: { inputs: ["reset", "inc"], outputs: [], byteInputs: ["load"], byteOutputs: ["count"] },
+  RAM2: { inputs: ["a0", "we"], outputs: [], byteInputs: ["data"], byteOutputs: ["out"] },
+  RAM4: { inputs: ["a0", "a1", "we"], outputs: [], byteInputs: ["data"], byteOutputs: ["out"] },
+  RAM8: { inputs: ["a0", "a1", "a2", "we"], outputs: [], byteInputs: ["data"], byteOutputs: ["out"] },
+  RAM16: { inputs: ["a0", "a1", "a2", "a3", "we"], outputs: [], byteInputs: ["data"], byteOutputs: ["out"] },
 };
 
 function resolveModulePorts(
@@ -66,6 +70,7 @@ export type NodeData = {
   byteInputs: string[];
   byteOutputs: string[];
   value?: boolean | number;
+  memoryDump?: number[];
 };
 
 export function astToGraph(ast: Program): {
@@ -107,6 +112,7 @@ export function astToGraph(ast: Program): {
     else if (st.moduleName === "BYTEOUT") nodeType = "byteoutNode";
     else if (st.moduleName === "NAND") nodeType = "nandNode";
     else if (st.moduleName === "FLIPFLOP") nodeType = "flipflopNode";
+    else if (st.moduleName.startsWith("RAM")) nodeType = "ramNode";
     else nodeType = "moduleNode";
 
     nodes.push({

--- a/packages/viewer/src/lib/puzzles.ts
+++ b/packages/viewer/src/lib/puzzles.ts
@@ -1194,4 +1194,160 @@ WIRE ctr count TO count _
     availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "MUX", "DMUX", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH", "REG", "COUNTER", "BYTESPLIT", "BYTEMERGE"],
     helpSections: ["mod-counter", "mod-bytein", "mod-byteout"],
   },
+  {
+    id: 25,
+    title: "Lv25: RAM2",
+    description:
+      "RAM2は2アドレス（アドレスビット1本）の8ビットメモリです。\n\n" +
+      "入力:\n" +
+      "  a0（BIT）= アドレス（0または1）\n" +
+      "  we（BIT）= Write Enable（1で書き込み）\n" +
+      "  data（BYTE）= 書き込みデータ\n\n" +
+      "出力:\n" +
+      "  out（BYTE）= 指定アドレスの現在の値\n\n" +
+      "we=1のとき、dataの値がmemory[a0]に書き込まれます。\n" +
+      "outは常にmemory[a0]の値を出力します。初期値はすべて0です。\n\n" +
+      "RAM2モジュールを配置して、入力と出力を正しく結線してください。",
+    inputNames: ["a0", "we", "data"],
+    outputNames: ["out"],
+    testCases: [
+      // 初期状態: 両アドレスとも0
+      tc({ a0: false, we: false, data: 0 }, { out: 0 }),
+      tc({ a0: true, we: false, data: 0 }, { out: 0 }),
+      // we=0 では書き込まない
+      tc({ a0: false, we: false, data: 123 }, { out: 0 }),
+      tc({ a0: true, we: false, data: 200 }, { out: 0 }),
+      // Write 42 to addr0
+      tc({ a0: false, we: true, data: 42 }, { out: 42 }),
+      // Read addr0 → 42, addr1 → 0
+      tc({ a0: false, we: false, data: 0 }, { out: 42 }),
+      tc({ a0: true, we: false, data: 0 }, { out: 0 }),
+      // Write 99 to addr1
+      tc({ a0: true, we: true, data: 99 }, { out: 99 }),
+      // 両方読み出し確認
+      tc({ a0: false, we: false, data: 0 }, { out: 42 }),
+      tc({ a0: true, we: false, data: 0 }, { out: 99 }),
+      // 上書き: addr0 を 255 に
+      tc({ a0: false, we: true, data: 255 }, { out: 255 }),
+      tc({ a0: true, we: false, data: 0 }, { out: 99 }),  // addr1 不変
+      // 上書き: addr1 を 170 (10101010) に
+      tc({ a0: true, we: true, data: 170 }, { out: 170 }),
+      tc({ a0: false, we: false, data: 0 }, { out: 255 }),  // addr0 不変
+      // 連続書き込み
+      tc({ a0: false, we: true, data: 1 }, { out: 1 }),
+      tc({ a0: true, we: true, data: 2 }, { out: 2 }),
+      tc({ a0: false, we: true, data: 3 }, { out: 3 }),
+      tc({ a0: true, we: true, data: 4 }, { out: 4 }),
+      // 読み出し確認（最後の値が残る）
+      tc({ a0: false, we: false, data: 0 }, { out: 3 }),
+      tc({ a0: true, we: false, data: 0 }, { out: 4 }),
+      // 0 を書き込み
+      tc({ a0: false, we: true, data: 0 }, { out: 0 }),
+      tc({ a0: true, we: true, data: 0 }, { out: 0 }),
+      // 全クリア確認
+      tc({ a0: false, we: false, data: 0 }, { out: 0 }),
+      tc({ a0: true, we: false, data: 0 }, { out: 0 }),
+      // ビットパターン確認
+      tc({ a0: false, we: true, data: 85 }, { out: 85 }),   // 01010101
+      tc({ a0: true, we: true, data: 170 }, { out: 170 }),  // 10101010
+      tc({ a0: false, we: false, data: 0 }, { out: 85 }),
+      tc({ a0: true, we: false, data: 0 }, { out: 170 }),
+    ],
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${MUX}${DMUX}${ADD}${DEC}${ENC}${DLATCH}${REG}`,
+    fixedCode: `VAR a0 BITIN\nVAR we BITIN\nVAR data BYTEIN\nVAR out BYTEOUT`,
+    editableCode: `VAR ram RAM2
+WIRE a0 _ TO ram a0
+WIRE we _ TO ram we
+WIRE data _ TO ram data
+WIRE ram out TO out _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "MUX", "DMUX", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH", "REG", "COUNTER", "RAM2", "BYTESPLIT", "BYTEMERGE"],
+    helpSections: ["mod-ram", "mod-bytein", "mod-byteout"],
+  },
+  {
+    id: 26,
+    title: "Lv26: RAM16",
+    description:
+      "RAM16は16アドレス（アドレスビット4本）の8ビットメモリです。\n\n" +
+      "入力:\n" +
+      "  a0〜a3（BIT）= アドレス（0〜15）\n" +
+      "  we（BIT）= Write Enable（1で書き込み）\n" +
+      "  data（BYTE）= 書き込みデータ\n\n" +
+      "出力:\n" +
+      "  out（BYTE）= 指定アドレスの現在の値\n\n" +
+      "RAM2と同じ動作ですが、アドレス空間が16に拡大されています。\n" +
+      "複数のアドレスに書き込み、正しく読み出せることを確認しましょう。",
+    inputNames: ["a0", "a1", "a2", "a3", "we", "data"],
+    outputNames: ["out"],
+    testCases: (() => {
+      const a = (addr: number, we: boolean, data: number) => ({
+        a0: (addr & 1) === 1, a1: (addr & 2) === 2,
+        a2: (addr & 4) === 4, a3: (addr & 8) === 8,
+        we, data,
+      });
+      return [
+        // 初期状態: 未書き込みアドレスは0
+        tc(a(0, false, 0), { out: 0 }),
+        tc(a(7, false, 0), { out: 0 }),
+        tc(a(15, false, 0), { out: 0 }),
+        // 全16アドレスに書き込み (addr * 16 + 1)
+        tc(a(0, true, 1), { out: 1 }),
+        tc(a(1, true, 17), { out: 17 }),
+        tc(a(2, true, 33), { out: 33 }),
+        tc(a(3, true, 49), { out: 49 }),
+        tc(a(4, true, 65), { out: 65 }),
+        tc(a(5, true, 81), { out: 81 }),
+        tc(a(6, true, 97), { out: 97 }),
+        tc(a(7, true, 113), { out: 113 }),
+        tc(a(8, true, 129), { out: 129 }),
+        tc(a(9, true, 145), { out: 145 }),
+        tc(a(10, true, 161), { out: 161 }),
+        tc(a(11, true, 177), { out: 177 }),
+        tc(a(12, true, 193), { out: 193 }),
+        tc(a(13, true, 209), { out: 209 }),
+        tc(a(14, true, 225), { out: 225 }),
+        tc(a(15, true, 241), { out: 241 }),
+        // 全アドレス読み出し確認（逆順）
+        tc(a(15, false, 0), { out: 241 }),
+        tc(a(14, false, 0), { out: 225 }),
+        tc(a(13, false, 0), { out: 209 }),
+        tc(a(12, false, 0), { out: 193 }),
+        tc(a(11, false, 0), { out: 177 }),
+        tc(a(10, false, 0), { out: 161 }),
+        tc(a(9, false, 0), { out: 145 }),
+        tc(a(8, false, 0), { out: 129 }),
+        tc(a(7, false, 0), { out: 113 }),
+        tc(a(6, false, 0), { out: 97 }),
+        tc(a(5, false, 0), { out: 81 }),
+        tc(a(4, false, 0), { out: 65 }),
+        tc(a(3, false, 0), { out: 49 }),
+        tc(a(2, false, 0), { out: 33 }),
+        tc(a(1, false, 0), { out: 17 }),
+        tc(a(0, false, 0), { out: 1 }),
+        // we=0 では書き込まれない
+        tc(a(0, false, 200), { out: 1 }),
+        tc(a(15, false, 200), { out: 241 }),
+        // 上書きテスト
+        tc(a(3, true, 255), { out: 255 }),
+        tc(a(3, false, 0), { out: 255 }),
+        tc(a(4, false, 0), { out: 65 }),   // 隣は変わらない
+        tc(a(12, true, 0), { out: 0 }),
+        tc(a(12, false, 0), { out: 0 }),
+        tc(a(11, false, 0), { out: 177 }), // 隣は変わらない
+      ];
+    })(),
+    moduleDefs: `${NOT}${AND}${OR}${NOR}${XOR}${XNOR}${AND3}${OR3}${MUX}${DMUX}${ADD}${DEC}${ENC}${DLATCH}${REG}`,
+    fixedCode: `VAR a0 BITIN\nVAR a1 BITIN\nVAR a2 BITIN\nVAR a3 BITIN\nVAR we BITIN\nVAR data BYTEIN\nVAR out BYTEOUT`,
+    editableCode: `VAR ram RAM16
+WIRE a0 _ TO ram a0
+WIRE a1 _ TO ram a1
+WIRE a2 _ TO ram a2
+WIRE a3 _ TO ram a3
+WIRE we _ TO ram we
+WIRE data _ TO ram data
+WIRE ram out TO out _
+`,
+    availableModules: ["NAND", "NOT", "AND", "OR", "NOR", "XOR", "XNOR", "AND3", "OR3", "MUX", "DMUX", "ADD", "DEC", "ENC", "FLIPFLOP", "DLATCH", "REG", "COUNTER", "RAM2", "RAM4", "RAM8", "RAM16", "BYTESPLIT", "BYTEMERGE"],
+    helpSections: ["mod-ram", "mod-bytein", "mod-byteout"],
+  },
 ];

--- a/packages/viewer/src/pages/SandboxPage.tsx
+++ b/packages/viewer/src/pages/SandboxPage.tsx
@@ -16,15 +16,23 @@ const PRELOADED_MODULES = `${ON}${NOT}${AND}${AND3}${OR}${OR3}${NOR}${XOR}${XNOR
 const AVAILABLE_MODULE_NAMES = [
   "ON", "NOT", "AND", "AND3", "OR", "OR3", "NOR", "XOR", "XNOR",
   "ADD", "DEC", "ENC", "BYTEADD", "DLATCH", "MUX", "DMUX",
+  "RAM2", "RAM4", "RAM8", "RAM16",
 ];
 
-const DEFAULT_CODE = `VAR a BITIN
-VAR b BITIN
-VAR out BITOUT
-VAR nand NAND
-WIRE a _ TO nand i0
-WIRE b _ TO nand i1
-WIRE nand _ TO out _
+const DEFAULT_CODE = `# RAM4 を使った簡易メモリ回路
+# a0,a1でアドレス指定、weで書き込み、dataで値を入力
+VAR a0 BITIN
+VAR a1 BITIN
+VAR we BITIN
+VAR data BYTEIN
+VAR out BYTEOUT
+
+VAR ram RAM4
+WIRE a0 _ TO ram a0
+WIRE a1 _ TO ram a1
+WIRE we _ TO ram we
+WIRE data _ TO ram data
+WIRE ram out TO out _
 `;
 
 export function SandboxPage() {


### PR DESCRIPTION
## Summary
- `RamModule` クラスを追加（アドレスビット数パラメータ化、8bitデータ幅）
- RAM2(2addr), RAM4(4addr), RAM8(8addr), RAM16(16addr) の4種類を組み込みモジュールとして登録
- ビューワに `RamNode` コンポーネントを追加し、内部メモリ状態をグリッド表示（非ゼロ値をハイライト）
- パズル Lv25(RAM2), Lv26(RAM16) を追加
- ヘルプマニュアルに RAM セクション追加
- Sandbox で RAM モジュールを使用可能に（利用可能モジュール一覧＋初期サンプルコード）

## Test plan
- [x] `npm test` で language パッケージのユニットテスト通過（RAM の write/read/we=0/独立アドレス保持）
- [ ] ビューワで Lv25(RAM2), Lv26(RAM16) のパズルが正しく動作するか確認
- [ ] グラフ表示で RAM ノードのポートとメモリ状態が正しく描画されるか確認
- [ ] Sandbox で RAM モジュールを使った回路が動作するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)