### PR TITLE
ノードの表示改善: bytein/byteout縮小とポートラベル圧縮

### DIFF
--- a/packages/viewer/src/components/nodes/ModuleNode.tsx
+++ b/packages/viewer/src/components/nodes/ModuleNode.tsx
@@ -2,6 +2,26 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { NodeData } from "../../lib/astToGraph";
 import "./nodeStyles.css";
 
+/**
+ * Compress sequential port names like ["i0","i1","i2","i3"] → "i0~i3"
+ * Falls back to comma-joined if ports are not sequential.
+ */
+function compressPortLabels(labels: string[]): string {
+  if (labels.length <= 2) return labels.join(", ");
+  // Check if all labels share a common prefix followed by sequential numbers
+  const match0 = labels[0].match(/^(.+?)(\d+)$/);
+  if (!match0) return labels.join(", ");
+  const prefix = match0[1];
+  const startNum = Number(match0[2]);
+  for (let i = 1; i < labels.length; i++) {
+    const m = labels[i].match(/^(.+?)(\d+)$/);
+    if (!m || m[1] !== prefix || Number(m[2]) !== startNum + i) {
+      return labels.join(", ");
+    }
+  }
+  return `${labels[0]}~${labels[labels.length - 1]}`;
+}
+
 export function ModuleNode({ data }: NodeProps & { data: NodeData }) {
   const inputs = data.inputs;
   const outputs = data.outputs;
@@ -45,9 +65,13 @@ export function ModuleNode({ data }: NodeProps & { data: NodeData }) {
       <div className="node-label">{data.label}</div>
       <div className="node-type">{data.moduleName}</div>
       {maxPorts > 1 && (
-        <div style={{ display: "flex", justifyContent: "space-between", fontSize: 9, color: "#aaa", marginTop: 4 }}>
-          <span>{portLabels.join(", ")}</span>
-          <span>{outLabels.join(", ")}</span>
+        <div style={{ fontSize: 9, color: "#aaa", marginTop: 4 }}>
+          {portLabels.length > 0 && (
+            <div style={{ textAlign: "left" }}>{compressPortLabels(portLabels)}</div>
+          )}
+          {outLabels.length > 0 && (
+            <div style={{ textAlign: "right" }}>{compressPortLabels(outLabels)}</div>
+          )}
         </div>
       )}
       {allOutputHandles.map((handle, i) => (

--- a/packages/viewer/src/components/nodes/nodeStyles.css
+++ b/packages/viewer/src/components/nodes/nodeStyles.css
@@ -58,12 +58,10 @@
 
 .bytein-node {
   border-color: #4a9eff;
-  min-height: 180px;
 }
 
 .byteout-node {
   border-color: #ff6b6b;
-  min-height: 180px;
 }
 
 .byte-value-display {


### PR DESCRIPTION
## Summary
- bytein/byteoutノードの不要な`min-height: 180px`を削除し、コンテンツに合ったサイズに縮小
- ModuleNodeの連番ポートラベルを圧縮表示（例: `i0, i1, ..., i7` → `i0~i7`）
- inポートとoutポートのラベルを別行に分けて表示（左寄せ/右寄せ）

## Test plan
- [ ] bytein/byteoutノードが縦長でなくなっていることを確認
- [ ] DEC/ENCなど多ポートモジュールのラベルが圧縮表示されることを確認
- [ ] 2ポート以下のモジュール（NANDなど）は従来通り表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)